### PR TITLE
Add CV landing page

### DIFF
--- a/cv/index.html
+++ b/cv/index.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MinhjiH | CV</title>
+    <meta
+      name="description"
+      content="minhjih의 이력서 전용 페이지. 곧 이력서 내용을 추가할 예정입니다."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Noto+Sans+KR:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <section class="hero">
+        <div class="hero__intro">
+          <span class="hero__tag">Resume space</span>
+          <h1 class="hero__title">민지의 이력서 페이지</h1>
+          <p class="hero__subtitle">
+            현재는 전체 레이아웃과 톤을 먼저 정리해 두었고, 이력서 내용을 전달받으면
+            빠르게 채워 넣을 수 있도록 섹션을 구성해 두었습니다.
+          </p>
+          <div class="hero__actions">
+            <a class="button" href="mailto:hello@minhjih.com">연락하기</a>
+            <a class="button" href="#timeline">커리어 타임라인</a>
+          </div>
+        </div>
+        <article class="hero__card">
+          <h3>Profile Snapshot</h3>
+          <ul class="hero__list">
+            <li>
+              <span>한 줄 소개</span>
+              감각적인 제품 경험을 만드는 디자이너/개발자 (내용 예정)
+            </li>
+            <li>
+              <span>주요 키워드</span>
+              Product Design · Front-end · Branding
+            </li>
+            <li>
+              <span>거점</span>
+              Seoul · Remote
+            </li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="section-grid" aria-label="highlights">
+        <article class="section-card">
+          <h4>Highlights</h4>
+          <p>중요 성과 2~3개를 카드 형태로 강조할 공간입니다.</p>
+          <p class="placeholder">예시: 신규 서비스 런칭, MAU 성장, 디자인 시스템 구축</p>
+        </article>
+        <article class="section-card">
+          <h4>Core Skills</h4>
+          <p>핵심 역량을 태그/짧은 문장으로 배치합니다.</p>
+          <p class="placeholder">예시: UX Research, React, Prototyping, Storytelling</p>
+        </article>
+        <article class="section-card">
+          <h4>Contact</h4>
+          <p>이메일/포트폴리오 링크를 배치할 섹션입니다.</p>
+          <p class="placeholder">예시: hello@minhjih.com · behance.net/...</p>
+        </article>
+      </section>
+
+      <section class="split" id="timeline">
+        <article>
+          <h3>Experience</h3>
+          <ul class="list">
+            <li>
+              <strong>회사명 · 직무</strong>
+              <div class="placeholder">2022.01 - 현재 · 주요 역할 요약 예정</div>
+            </li>
+            <li>
+              <strong>회사명 · 직무</strong>
+              <div class="placeholder">2020.03 - 2021.12 · 주요 역할 요약 예정</div>
+            </li>
+            <li>
+              <strong>회사명 · 프로젝트</strong>
+              <div class="placeholder">단기 프로젝트/프리랜스 경험 요약 예정</div>
+            </li>
+          </ul>
+        </article>
+        <article>
+          <h3>Projects</h3>
+          <ul class="list">
+            <li>
+              <strong>프로젝트 이름</strong>
+              <div class="placeholder">문제 정의, 기여 내용, 성과를 작성할 공간입니다.</div>
+            </li>
+            <li>
+              <strong>프로젝트 이름</strong>
+              <div class="placeholder">핵심 역할과 영향력을 요약합니다.</div>
+            </li>
+            <li>
+              <strong>프로젝트 이름</strong>
+              <div class="placeholder">링크 및 사용 기술 스택을 정리합니다.</div>
+            </li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="split">
+        <article>
+          <h3>Education</h3>
+          <ul class="list">
+            <li>
+              <strong>학교명 · 전공</strong>
+              <div class="placeholder">졸업 연도 및 주요 활동 예정</div>
+            </li>
+            <li>
+              <strong>프로그램/수료 과정</strong>
+              <div class="placeholder">수료 연도 및 집중 분야 예정</div>
+            </li>
+          </ul>
+        </article>
+        <article>
+          <h3>Extras</h3>
+          <ul class="list">
+            <li>
+              <strong>수상/자격증</strong>
+              <div class="placeholder">수상명 또는 자격증 정보를 정리합니다.</div>
+            </li>
+            <li>
+              <strong>커뮤니티/발표</strong>
+              <div class="placeholder">발표 주제, 커뮤니티 활동 요약 예정</div>
+            </li>
+          </ul>
+        </article>
+      </section>
+
+      <footer class="footer">
+        <span>Resume content update pending.</span>
+        <span class="footer__badge">minhjih.github.io/cv</span>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/cv/styles.css
+++ b/cv/styles.css
@@ -1,0 +1,197 @@
+:root {
+  color-scheme: light;
+  font-family: "Pretendard", "Noto Sans KR", "Inter", system-ui, -apple-system, sans-serif;
+  background-color: #0f1115;
+  color: #f8f8fb;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: radial-gradient(circle at top, rgba(93, 104, 255, 0.25), transparent 40%),
+    radial-gradient(circle at 20% 40%, rgba(255, 145, 77, 0.18), transparent 35%),
+    #0f1115;
+  color: inherit;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 56px 24px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+  align-items: center;
+}
+
+.hero__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero__tag {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.24em;
+  color: rgba(248, 248, 251, 0.65);
+}
+
+.hero__title {
+  font-size: clamp(32px, 5vw, 56px);
+  font-weight: 600;
+  line-height: 1.1;
+}
+
+.hero__subtitle {
+  font-size: 18px;
+  line-height: 1.6;
+  color: rgba(248, 248, 251, 0.7);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.button {
+  padding: 12px 20px;
+  border-radius: 999px;
+  font-size: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.hero__card {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  padding: 24px;
+  display: grid;
+  gap: 18px;
+  backdrop-filter: blur(12px);
+}
+
+.hero__card h3 {
+  font-size: 18px;
+}
+
+.hero__list {
+  list-style: none;
+  display: grid;
+  gap: 12px;
+  color: rgba(248, 248, 251, 0.8);
+  font-size: 14px;
+}
+
+.hero__list span {
+  display: block;
+  font-weight: 600;
+  color: #ffffff;
+  margin-bottom: 4px;
+}
+
+.section-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.section-card {
+  padding: 20px 22px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: grid;
+  gap: 12px;
+}
+
+.section-card h4 {
+  font-size: 16px;
+}
+
+.section-card p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: rgba(248, 248, 251, 0.7);
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.list {
+  list-style: none;
+  display: grid;
+  gap: 16px;
+}
+
+.list li {
+  padding: 16px 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(15, 17, 21, 0.7);
+}
+
+.list strong {
+  display: block;
+  font-size: 15px;
+  margin-bottom: 6px;
+}
+
+.placeholder {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 13px;
+}
+
+.footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  color: rgba(248, 248, 251, 0.6);
+}
+
+.footer__badge {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+@media (max-width: 600px) {
+  .page {
+    padding: 40px 20px 64px;
+  }
+
+  .hero__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a dedicated resume page served at `minhjih.github.io/cv` so the site can host a personal CV landing area.
- Establish a clean, modern layout and visual tone so resume content can be filled in quickly when provided.
- Present information in a card-style, dark-gradient design for an aesthetic and readable CV experience.

### Description
- Add `cv/index.html` containing semantic sections for hero, highlights, experience, projects, education, extras, and footer with placeholder content.
- Add `cv/styles.css` implementing a responsive dark gradient theme, card components, and typography using Google Fonts.
- Include basic actions such as a `mailto:` contact button and an internal anchor to the timeline for quick navigation.

### Testing
- Launched a local static server with `python -m http.server 8000` and served the new `cv` directory successfully.
- Executed a Playwright script to open `http://127.0.0.1:8000/cv/` and capture a full-page screenshot, which completed successfully.
- No unit tests were added for this static UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f90bc20d0832ea1bbfba21a8f23fc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Creates a dedicated, responsive CV landing page with a dark gradient aesthetic and semantic sections ready for content.
> 
> - Adds `cv/index.html` with hero, highlights, experience, projects, education, extras, and footer; includes `mailto:` contact and in-page timeline anchor
> - Introduces `cv/styles.css` for responsive layout, card components, and typography using Google Fonts; includes mobile tweaks and visual polish
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94012f3202ac4f88bd97e722e21218f3c36a5ee5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->