### PR TITLE
Restyle CV page to calm single-column resume

### DIFF
--- a/cv/index.html
+++ b/cv/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Jaehyun Choi | CV</title>
+    <meta
+      name="description"
+      content="Jaehyun Choi의 이력서 페이지. 연구 경험, 해커톤, 기술 스택, 수상 이력을 정리했습니다."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Noto+Sans+KR:wght@300;400;500&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="page">
+      <header class="header">
+        <div>
+          <p class="eyebrow">Curriculum Vitae</p>
+          <h1 class="name">Jaehyun Choi</h1>
+          <p class="role">M.S./Ph.D. Student, Electrical and Computer Engineering</p>
+          <p class="location">Seoul National University</p>
+        </div>
+        <div class="contact">
+          <p>Email: <a href="mailto:jhchoi0226@snu.ac.kr">jhchoi0226@snu.ac.kr</a></p>
+          <p>GitHub: <a href="https://github.com/minhjih">github.com/minhjih</a></p>
+        </div>
+      </header>
+
+      <section class="section">
+        <h2>Research Interests</h2>
+        <p class="lead">
+          AI-RAN, Digital Twin, Ray-Tracing Simulation, Learning-based Systems, Foundation Model,
+          Robot Control
+        </p>
+      </section>
+
+      <section class="section">
+        <h2>Education</h2>
+        <div class="entry">
+          <div>
+            <h3>Seoul National University (SNU)</h3>
+            <p class="meta">M.S./Ph.D. Integrated Program, Electrical and Computer Engineering</p>
+          </div>
+          <span class="year">Present</span>
+        </div>
+        <div class="entry">
+          <div>
+            <h3>POSTECH (Pohang University of Science and Technology)</h3>
+            <p class="meta">B.S. in Electrical Engineering</p>
+          </div>
+          <span class="year">Graduated</span>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Research Experience</h2>
+        <div class="card">
+          <h3>
+            RT-AugGAN: Robust Fingerprint Positioning under Environmental Variations via Ray
+            Tracing-Assisted GAN Augmentation
+          </h3>
+          <p class="meta">IEEE/IEIE ICCE-ASIA 2025 · Accepted</p>
+          <ul>
+            <li>
+              Developed a ray tracing-assisted data augmentation framework combining digital twin
+              simulation and generative modeling.
+            </li>
+            <li>
+              Built high-fidelity wireless environments using NVIDIA Omniverse and Sionna RT for
+              realistic CSI generation.
+            </li>
+            <li>
+              Designed and trained GAN-based models to improve robustness of fingerprint-based
+              positioning systems.
+            </li>
+            <li>
+              Analyzed generalization performance under environmental variations using simulated and
+              real-world data.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Hackathon &amp; Competition Experience</h2>
+        <div class="card">
+          <h3>2025 Likelion Blackout Hackathon</h3>
+          <p class="meta">Overall Winner / GCOO Track Winner · GARi</p>
+          <ul>
+            <li>Implemented AI-based safety driving and parking assessment for shared mobility.</li>
+            <li>Collected real-world driving video data on-site under severe time constraints.</li>
+            <li>Developed computer vision pipelines for driving behavior analysis and inference.</li>
+            <li>Collaborated with frontend and backend teams to integrate AI outputs.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Chung Ju-yung Startup Competition: Asan Doers</h3>
+          <p class="meta">Finalist · Reveal: Research Tracking &amp; Knowledge Sharing Platform</p>
+          <ul>
+            <li>Proposed a platform for tracking research trends and sharing short-form insights.</li>
+            <li>Participated in system design and product planning discussions.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Science Hackathon (SPARCS)</h3>
+          <p class="meta">Second Prize · ScienSnap</p>
+          <ul>
+            <li>Developed an AI-based application mapping everyday images to scientific concepts.</li>
+            <li>Implemented classification and ranking mechanisms for educational content.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>DataEn OIBC 2024 Big Data Challenge</h3>
+          <p class="meta">Third Prize · Jeju Electricity Market Forecasting</p>
+          <ul>
+            <li>Designed a hybrid model combining RNN, SARIMA, and Transformer architectures.</li>
+            <li>Achieved stable prediction performance under fluctuating market conditions.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Technical Skills</h2>
+        <div class="skills">
+          <div>
+            <h3>Programming Languages</h3>
+            <p>Python (Advanced), C++ (Advanced), Verilog, Assembly Language</p>
+          </div>
+          <div>
+            <h3>Deep Learning</h3>
+            <p>PyTorch, Hugging Face</p>
+          </div>
+          <div>
+            <h3>Simulation &amp; Digital Twin</h3>
+            <p>Blender, NVIDIA Omniverse, Sionna RT, Ray Tracing</p>
+          </div>
+          <div>
+            <h3>Backend &amp; Systems</h3>
+            <p>Flask, FastAPI, Docker, Linux</p>
+          </div>
+          <div>
+            <h3>Cloud &amp; Database</h3>
+            <p>AWS EC2, PostgreSQL</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <h2>Honors</h2>
+        <div class="card">
+          <h3>KEPCO Academic Scholarship</h3>
+          <p class="meta">2023 · Korea Electric Power Corporation</p>
+          <p>
+            Selected as a national scholarship recipient based on academic excellence and potential
+            in the energy sector.
+          </p>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/cv/styles.css
+++ b/cv/styles.css
@@ -1,0 +1,163 @@
+:root {
+  font-family: "Noto Sans KR", system-ui, -apple-system, sans-serif;
+  color: #2f2f2f;
+  background-color: #f6f2ec;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: #f6f2ec;
+  color: inherit;
+  line-height: 1.6;
+}
+
+a {
+  color: #2f2f2f;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(47, 47, 47, 0.2);
+}
+
+a:hover {
+  border-bottom-color: rgba(47, 47, 47, 0.6);
+}
+
+.page {
+  width: 900px;
+  margin: 60px auto;
+  padding: 48px 56px;
+  background-color: #fffdf9;
+  border: 1px solid #e4ddd4;
+  box-shadow: 0 12px 30px rgba(63, 56, 47, 0.08);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid #e6ded3;
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  font-family: "Libre Baskerville", serif;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #7c7268;
+  margin-bottom: 8px;
+}
+
+.name {
+  font-family: "Libre Baskerville", serif;
+  font-size: 36px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.role,
+.location {
+  font-size: 15px;
+  color: #5a524a;
+}
+
+.contact {
+  text-align: right;
+  font-size: 14px;
+  color: #5a524a;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.section {
+  margin-bottom: 32px;
+}
+
+.section h2 {
+  font-family: "Libre Baskerville", serif;
+  font-size: 20px;
+  margin-bottom: 16px;
+  color: #3b342f;
+}
+
+.lead {
+  font-size: 15px;
+  color: #5a524a;
+}
+
+.entry {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid #eee6dc;
+}
+
+.entry:last-of-type {
+  border-bottom: none;
+}
+
+.entry h3 {
+  font-size: 16px;
+  margin-bottom: 4px;
+  color: #2f2f2f;
+}
+
+.meta {
+  font-size: 14px;
+  color: #7a6f65;
+}
+
+.year {
+  font-size: 14px;
+  color: #7a6f65;
+  white-space: nowrap;
+}
+
+.card {
+  padding: 16px 18px;
+  border: 1px solid #e9e1d7;
+  background-color: #faf6f1;
+  margin-bottom: 16px;
+}
+
+.card h3 {
+  font-size: 16px;
+  margin-bottom: 6px;
+}
+
+.card ul {
+  padding-left: 20px;
+  color: #4d453f;
+  font-size: 14px;
+  display: grid;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.card p {
+  font-size: 14px;
+  color: #4d453f;
+}
+
+.skills {
+  display: grid;
+  gap: 14px;
+}
+
+.skills h3 {
+  font-size: 15px;
+  margin-bottom: 4px;
+  color: #2f2f2f;
+}
+
+.skills p {
+  font-size: 14px;
+  color: #5a524a;
+}


### PR DESCRIPTION
### Motivation
- Replace the previous dark/complex layout with a calm, personal resume-style page to address visual complaints that the design felt broken and unfocused. 
- Provide a simple, single-column presentation that reads like a printed CV rather than an app-like landing page. 
- Remove responsive/complex layout behavior per request so the page is intentionally static and non-responsive. 

### Description
- Add `cv/index.html` with structured sections for contact, research interests, education, research experience, competitions, skills, and honors. 
- Add `cv/styles.css` implementing a light, paper-like palette, simplified typography (Google Fonts), single-column cards, and understated borders/shadows. 
- Rework layout to single-column card entries and remove responsive media-query behavior to keep the design static. 
- Ensure links use `mailto:` and a GitHub link are present in the contact area. 

### Testing
- Launched a local static server using `python -m http.server 8000` and confirmed the site served the `cv` directory successfully. 
- Ran a Playwright script to open `http://127.0.0.1:8000/cv/` and capture a full-page screenshot saved as `artifacts/cv-page-calm.png`, which completed successfully. 
- Verified files `cv/index.html` and `cv/styles.css` were added and committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f90bc20d0832ea1bbfba21a8f23fc)