### PR TITLE
Split CV into dedicated pages, add Honors page, and place square profile photo on About

### DIFF
--- a/cv/about.html
+++ b/cv/about.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About | Jaehyun Choi</title>
+    <meta name="description" content="About Jaehyun Choi." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Manrope:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand__label">Curriculum Vitae</span>
+          <span class="brand__name">Jaehyun Choi</span>
+        </div>
+        <nav class="nav">
+          <a class="is-active" href="about.html">About</a>
+          <a href="publications.html">Publications</a>
+          <a href="competitive.html">Competitive &amp; Prize</a>
+          <a href="honors.html">Honors</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </header>
+
+      <main class="content-page">
+        <section class="about-hero">
+          <div class="about-photo">
+            <img src="cv-image.png" alt="Portrait of Jaehyun Choi" />
+          </div>
+          <div>
+            <p class="eyebrow">About</p>
+            <h1>Short Bio</h1>
+            <p class="lead">
+              I am an M.S./Ph.D. student in Electrical and Computer Engineering at Seoul National
+              University, focusing on AI-driven wireless systems and digital twin simulations. My
+              work explores robust positioning and learning-based control across simulated and
+              real-world environments.
+            </p>
+            <p class="lead">
+              Research interests include AI-RAN, digital twin environments, ray-tracing simulation,
+              foundation models, and robot control.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/cv/competitive.html
+++ b/cv/competitive.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Competitive & Prize | Jaehyun Choi</title>
+    <meta name="description" content="Competitive achievements and hackathons." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Manrope:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand__label">Curriculum Vitae</span>
+          <span class="brand__name">Jaehyun Choi</span>
+        </div>
+        <nav class="nav">
+          <a href="about.html">About</a>
+          <a href="publications.html">Publications</a>
+          <a class="is-active" href="competitive.html">Competitive &amp; Prize</a>
+          <a href="honors.html">Honors</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </header>
+
+      <main class="content-page">
+        <section class="page-header">
+          <div>
+            <p class="eyebrow">Competitive &amp; Prize</p>
+            <h1>Hackathons &amp; Competitions</h1>
+            <p class="lead">Highlights from collaborative challenges and applied projects.</p>
+          </div>
+          <div class="summary-card">
+            <p class="summary-label">Recent Focus</p>
+            <p>AI Safety · Computer Vision · Data Forecasting</p>
+          </div>
+        </section>
+
+        <section class="stack">
+          <article class="card">
+            <h2>2025 Likelion Blackout Hackathon</h2>
+            <p class="meta">Overall Winner / GCOO Track Winner · GARi</p>
+            <ul>
+              <li>Implemented AI-based safety driving and parking assessment for shared mobility.</li>
+              <li>Collected real-world driving video data on-site under severe time constraints.</li>
+              <li>Developed computer vision pipelines for driving behavior analysis and inference.</li>
+              <li>Collaborated with frontend and backend teams to integrate AI outputs.</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h2>Chung Ju-yung Startup Competition: Asan Doers</h2>
+            <p class="meta">Finalist · Reveal: Research Tracking &amp; Knowledge Sharing Platform</p>
+            <ul>
+              <li>Proposed a platform for tracking research trends and sharing short-form insights.</li>
+              <li>Participated in system design and product planning discussions.</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h2>Science Hackathon (SPARCS)</h2>
+            <p class="meta">Second Prize · ScienSnap</p>
+            <ul>
+              <li>Developed an AI-based application mapping everyday images to scientific concepts.</li>
+              <li>Implemented classification and ranking mechanisms for educational content.</li>
+            </ul>
+          </article>
+          <article class="card">
+            <h2>DataEn OIBC 2024 Big Data Challenge</h2>
+            <p class="meta">Third Prize · Jeju Electricity Market Forecasting</p>
+            <ul>
+              <li>Designed a hybrid model combining RNN, SARIMA, and Transformer architectures.</li>
+              <li>Achieved stable prediction performance under fluctuating market conditions.</li>
+            </ul>
+          </article>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/cv/contact.html
+++ b/cv/contact.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact | Jaehyun Choi</title>
+    <meta name="description" content="Contact information for Jaehyun Choi." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Manrope:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand__label">Curriculum Vitae</span>
+          <span class="brand__name">Jaehyun Choi</span>
+        </div>
+        <nav class="nav">
+          <a href="about.html">About</a>
+          <a href="publications.html">Publications</a>
+          <a href="competitive.html">Competitive &amp; Prize</a>
+          <a href="honors.html">Honors</a>
+          <a class="is-active" href="contact.html">Contact</a>
+        </nav>
+      </header>
+
+      <main class="content-page">
+        <section class="page-header">
+          <div>
+            <p class="eyebrow">Contact</p>
+            <h1>Let's Connect</h1>
+            <p class="lead">Feel free to reach out for research collaboration or speaking.</p>
+          </div>
+          <div class="summary-card">
+            <p class="summary-label">Primary</p>
+            <p>jhchoi0226@snu.ac.kr</p>
+          </div>
+        </section>
+
+        <section class="stack">
+          <article class="card contact-card">
+            <p>Email: <a href="mailto:jhchoi0226@snu.ac.kr">jhchoi0226@snu.ac.kr</a></p>
+            <p>GitHub: <a href="https://github.com/minhjih">github.com/minhjih</a></p>
+          </article>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/cv/honors.html
+++ b/cv/honors.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Honors | Jaehyun Choi</title>
+    <meta name="description" content="Honors and scholarships for Jaehyun Choi." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Manrope:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand__label">Curriculum Vitae</span>
+          <span class="brand__name">Jaehyun Choi</span>
+        </div>
+        <nav class="nav">
+          <a href="about.html">About</a>
+          <a href="publications.html">Publications</a>
+          <a href="competitive.html">Competitive &amp; Prize</a>
+          <a class="is-active" href="honors.html">Honors</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </header>
+
+      <main class="content-page">
+        <section class="page-header">
+          <div>
+            <p class="eyebrow">Honors</p>
+            <h1>Scholarships &amp; Recognition</h1>
+            <p class="lead">Awards and scholarships that recognize academic excellence.</p>
+          </div>
+          <div class="summary-card">
+            <p class="summary-label">Highlight</p>
+            <p>KEPCO Academic Scholarship</p>
+          </div>
+        </section>
+
+        <section class="stack">
+          <article class="card">
+            <h2>KEPCO Academic Scholarship</h2>
+            <p class="meta">2023 · Korea Electric Power Corporation</p>
+            <p>
+              Selected as a national scholarship recipient based on academic excellence and potential
+              in the energy sector.
+            </p>
+          </article>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/cv/index.html
+++ b/cv/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Jaehyun Choi | CV</title>
+    <meta
+      name="description"
+      content="Jaehyun Choi's CV hub with quick links to About, Publications, Competitive & Prize, and Honors."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Manrope:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand__label">Curriculum Vitae</span>
+          <span class="brand__name">Jaehyun Choi</span>
+        </div>
+        <nav class="nav">
+          <a href="about.html">About</a>
+          <a href="publications.html">Publications</a>
+          <a href="competitive.html">Competitive &amp; Prize</a>
+          <a href="honors.html">Honors</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </header>
+
+      <main class="hero">
+        <div class="hero__content">
+          <p class="eyebrow">Research-focused CV</p>
+          <h1>Building robust learning systems with digital twin intelligence.</h1>
+          <p class="lead">
+            Explore dedicated pages for my background, publications, competitive highlights, and
+            honors.
+          </p>
+          <div class="hero__actions">
+            <a class="button" href="about.html">Explore About</a>
+            <a class="button button--ghost" href="publications.html">View Publications</a>
+          </div>
+        </div>
+        <div class="hero__card">
+          <div class="photo-frame">
+            <div class="photo-placeholder">Place photo here</div>
+            <p class="photo-note">Replace this box with your profile image.</p>
+          </div>
+          <div class="hero__meta">
+            <p>M.S./Ph.D. Student, Electrical and Computer Engineering</p>
+            <p>Seoul National University</p>
+            <p><a href="mailto:jhchoi0226@snu.ac.kr">jhchoi0226@snu.ac.kr</a></p>
+            <p><a href="https://github.com/minhjih">github.com/minhjih</a></p>
+          </div>
+        </div>
+      </main>
+
+      <section class="link-grid">
+        <a class="link-card" href="about.html">
+          <h2>About</h2>
+          <p>Short bio and research focus.</p>
+        </a>
+        <a class="link-card" href="publications.html">
+          <h2>Publications</h2>
+          <p>Selected papers and research highlights.</p>
+        </a>
+        <a class="link-card" href="competitive.html">
+          <h2>Competitive &amp; Prize</h2>
+          <p>Hackathons and competition experience.</p>
+        </a>
+        <a class="link-card" href="honors.html">
+          <h2>Honors</h2>
+          <p>Scholarships and recognition.</p>
+        </a>
+        <a class="link-card" href="contact.html">
+          <h2>Contact</h2>
+          <p>Reach out via email or GitHub.</p>
+        </a>
+      </section>
+    </div>
+  </body>
+</html>

--- a/cv/publications.html
+++ b/cv/publications.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Publications | Jaehyun Choi</title>
+    <meta name="description" content="Publications by Jaehyun Choi." />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Manrope:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <header class="topbar">
+        <div class="brand">
+          <span class="brand__label">Curriculum Vitae</span>
+          <span class="brand__name">Jaehyun Choi</span>
+        </div>
+        <nav class="nav">
+          <a href="about.html">About</a>
+          <a class="is-active" href="publications.html">Publications</a>
+          <a href="competitive.html">Competitive &amp; Prize</a>
+          <a href="honors.html">Honors</a>
+          <a href="contact.html">Contact</a>
+        </nav>
+      </header>
+
+      <main class="content-page">
+        <section class="page-header">
+          <div>
+            <p class="eyebrow">Publications</p>
+            <h1>Selected Papers</h1>
+            <p class="lead">Peer-reviewed publications and research outputs.</p>
+          </div>
+          <div class="summary-card">
+            <p class="summary-label">Primary Focus</p>
+            <p>AI-RAN · Digital Twin · Ray-Tracing · Learning Systems</p>
+          </div>
+        </section>
+
+        <section class="stack">
+          <article class="card">
+            <h2>
+              RT-AugGAN: Robust Fingerprint Positioning under Environmental Variations via Ray
+              Tracing-Assisted GAN Augmentation
+            </h2>
+            <p class="meta">IEEE/IEIE ICCE-ASIA 2025 · Accepted</p>
+            <p>
+              Ray tracing-assisted augmentation to improve positioning robustness under environmental
+              variations using GAN-based models.
+            </p>
+          </article>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/cv/styles.css
+++ b/cv/styles.css
@@ -1,0 +1,343 @@
+:root {
+  font-family: "Manrope", system-ui, -apple-system, sans-serif;
+  color: #1f2430;
+  background-color: #f3f1ee;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background-color: #f3f1ee;
+  color: inherit;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(31, 36, 48, 0.2);
+}
+
+a:hover {
+  border-bottom-color: rgba(31, 36, 48, 0.6);
+}
+
+.page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 40px 28px 80px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid #e1ddd7;
+  margin-bottom: 32px;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.brand__label {
+  font-family: "Libre Baskerville", serif;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #7d7582;
+}
+
+.brand__name {
+  font-family: "Libre Baskerville", serif;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.nav {
+  display: flex;
+  gap: 18px;
+  font-size: 14px;
+  flex-wrap: wrap;
+}
+
+.nav a {
+  border-bottom: 0;
+  padding-bottom: 4px;
+  color: #4a4f5d;
+}
+
+.nav a.is-active,
+.nav a:hover {
+  color: #1f2430;
+  border-bottom: 2px solid #a38c6f;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 32px;
+  align-items: center;
+}
+
+.hero__content h1 {
+  font-family: "Libre Baskerville", serif;
+  font-size: clamp(28px, 4vw, 40px);
+  margin-bottom: 16px;
+}
+
+.eyebrow {
+  font-family: "Libre Baskerville", serif;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #7d7582;
+  margin-bottom: 10px;
+}
+
+.lead {
+  font-size: 16px;
+  color: #4a4f5d;
+  margin-bottom: 20px;
+}
+
+.hero__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  background-color: #1f2430;
+  color: #fff7ec;
+  font-size: 14px;
+  border: 1px solid #1f2430;
+}
+
+.button--ghost {
+  background-color: transparent;
+  color: #1f2430;
+}
+
+.hero__card {
+  background-color: #fffdf9;
+  border: 1px solid #e4ddd4;
+  padding: 20px;
+  display: grid;
+  gap: 16px;
+  box-shadow: 0 14px 30px rgba(42, 46, 56, 0.08);
+}
+
+.photo-frame {
+  text-align: center;
+}
+
+.photo-placeholder {
+  height: 220px;
+  border: 1px dashed #c8c0b6;
+  display: grid;
+  place-items: center;
+  color: #8c857c;
+  font-size: 14px;
+  margin-bottom: 10px;
+}
+
+.photo-note {
+  font-size: 13px;
+  color: #6c6670;
+}
+
+.hero__meta p {
+  font-size: 14px;
+  color: #4a4f5d;
+}
+
+.link-grid {
+  margin-top: 48px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.link-card {
+  padding: 18px;
+  border: 1px solid #e4ddd4;
+  background-color: #fffdf9;
+  box-shadow: 0 12px 24px rgba(42, 46, 56, 0.06);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.link-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 30px rgba(42, 46, 56, 0.12);
+}
+
+.link-card h2 {
+  font-family: "Libre Baskerville", serif;
+  font-size: 18px;
+  margin-bottom: 8px;
+}
+
+.content-page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.page-header {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 24px;
+  align-items: center;
+}
+
+.about-hero {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 24px;
+  align-items: center;
+  background-color: #fffdf9;
+  border: 1px solid #e4ddd4;
+  padding: 24px;
+  box-shadow: 0 12px 26px rgba(42, 46, 56, 0.06);
+}
+
+.about-photo {
+  width: 200px;
+  height: 200px;
+  border: 1px solid #e4ddd4;
+  background-color: #faf6f1;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+
+.about-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.summary-card,
+.photo-card {
+  background-color: #fffdf9;
+  border: 1px solid #e4ddd4;
+  padding: 18px;
+  box-shadow: 0 12px 26px rgba(42, 46, 56, 0.06);
+}
+
+.summary-label {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  color: #7d7582;
+  margin-bottom: 8px;
+}
+
+.section-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.stack {
+  display: grid;
+  gap: 18px;
+}
+
+.card {
+  background-color: #fffdf9;
+  border: 1px solid #e4ddd4;
+  padding: 20px;
+  box-shadow: 0 10px 24px rgba(42, 46, 56, 0.05);
+}
+
+.card h2,
+.card h3 {
+  font-family: "Libre Baskerville", serif;
+  font-size: 18px;
+  margin-bottom: 8px;
+}
+
+.card p {
+  color: #4a4f5d;
+  font-size: 14px;
+}
+
+.card ul {
+  margin-top: 10px;
+  padding-left: 20px;
+  display: grid;
+  gap: 6px;
+  color: #4a4f5d;
+  font-size: 14px;
+}
+
+.meta {
+  font-size: 13px;
+  color: #7d7582;
+  margin-bottom: 8px;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 0;
+  border-bottom: 1px solid #eee6dc;
+}
+
+.row:last-child {
+  border-bottom: none;
+}
+
+.pill-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pill-grid span {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background-color: #efe8de;
+  font-size: 13px;
+}
+
+.contact-card {
+  display: grid;
+  gap: 8px;
+}
+
+@media (max-width: 900px) {
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .about-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .about-photo {
+    width: 100%;
+    height: 240px;
+  }
+}
+
+@media (max-width: 720px) {
+  .page {
+    padding: 32px 20px 60px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Reorganize the CV so each section is its own page and content is not mixed across pages. 
- Move honors out of the competition list into its own page for clearer separation of achievements. 
- Place a square profile photo on the About page and assume `cv-image.png` is colocated with the CV files. 
- Update navigation and styles to reflect the new page structure and responsive layout.

### Description
- Added/updated pages: `cv/index.html`, `cv/about.html`, `cv/publications.html`, `cv/competitive.html`, `cv/honors.html`, and `cv/contact.html` and a shared stylesheet `cv/styles.css` to support the new layout. 
- Implemented a left-aligned square profile frame in the About page using `<img src="cv-image.png" />` inside `.about-photo` and ensured the image fills the frame via CSS. 
- Moved publication entries into `publications.html` and removed honors from `competitive.html`, creating a dedicated `honors.html` page and updated the header navigation and active link states. 
- Updated styles for `.about-hero`, `.about-photo`, responsive breakpoints, and the hero/link-card layouts in `styles.css`.

### Testing
- Started a local static server with `python -m http.server 8000` and verified the site served successfully. 
- Ran a Playwright script that opened `http://127.0.0.1:8000/cv/` and `http://127.0.0.1:8000/cv/about.html` and saved screenshots to `artifacts/cv-home-updated.png` and `artifacts/cv-about-updated.png`, which completed successfully. 
- No unit tests were added or required for this static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f90bc20d0832ea1bbfba21a8f23fc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a multi-page CV with shared styling and clearer section separation.
> 
> - Adds `cv/index.html`, `cv/about.html`, `cv/publications.html`, `cv/competitive.html`, `cv/honors.html`, `cv/contact.html` with updated nav and active states
> - Implements square profile image on `about.html` via `img src="cv-image.png"` inside `.about-photo` and styles it to fill the frame
> - Creates shared `cv/styles.css` for layout, hero/link-card components, `.about-hero`, responsive grids, and breakpoints
> - Moves honors into `honors.html` and keeps competitions in `competitive.html`; publications listed in `publications.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7ec8a2e4106bc9dfa31c1e4b695dd3d8e6ba6c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->