### PR TITLE
후보별 현황 보기 전용화 (투표는 달력에서만)

### DIFF
--- a/seoulbremen/app.js
+++ b/seoulbremen/app.js
@@ -784,9 +784,7 @@ function renderPollSummary(candSet, mineSet) {
           <h3>${escapeHtml(label)} ${isTop ? '<span class="tag-next">최다</span>' : ""}</h3>
         </div>
         <div class="poll-count"><b>${voters.length}</b><span>표</span></div>
-        ${voted
-          ? `<span class="vote-badge">✓ 투표함</span>`
-          : `<button class="vote-btn" data-votedate="${escapeHtml(ds)}">🙋 가능</button>`}
+        ${voted ? `<span class="vote-badge">✓ 투표함</span>` : ""}
       </div>
       ${chips ? `<div class="poll-voters">${chips}</div>` : ``}
     </div>`;


### PR DESCRIPTION
"후보별 현황"을 완전히 보기 전용으로 변경. "🙋 가능" 버튼 제거 → 투표 선택/취소는 **달력에서만**. 투표한 항목은 `✓ 투표함` 표시만 유지.

https://claude.ai/code/session_01KC7AkYYRndPgM83qJz4tsj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KC7AkYYRndPgM83qJz4tsj)_