### PR TITLE
Seoul Bremen 배너 사진 + 일정 공유(카카오톡)

### DIFF
--- a/seoulbremen/app.js
+++ b/seoulbremen/app.js
@@ -361,15 +361,79 @@ async function uploadPhotos(files) {
 
 // ---------------- 렌더링 ----------------
 
-function renderHero(club, stats) {
-  document.getElementById("club-name").innerHTML = club.name
-    ? escapeHtml(club.name).replace(/(\S+)$/, '<span class="accent">$1</span>')
-    : "서울 <span class='accent'>브레멘</span>";
-  document.getElementById("tagline").textContent = club.tagline || "";
-  document.getElementById("desc").textContent = club.description || "";
-  document.getElementById("stat-rehearsals").textContent = stats.rehearsals;
-  document.getElementById("stat-songs").textContent = stats.songs;
-  document.getElementById("stat-photos").textContent = stats.photos;
+// 상단 배너 사진: config의 BANNER_URL, 없으면 갤러리 첫 사진
+function setBanner() {
+  const hero = document.getElementById("hero");
+  if (!hero) return;
+  const url = CFG.BANNER_URL
+    ? driveImageUrl(CFG.BANNER_URL, "w1600")
+    : (STATE.photos.find((p) => p.src) || {}).src || "";
+  if (url) {
+    hero.style.backgroundImage =
+      `linear-gradient(rgba(14,13,19,0.45), rgba(14,13,19,0.82)), url("${url}")`;
+    hero.classList.add("has-banner");
+  } else {
+    hero.style.backgroundImage = "";
+    hero.classList.remove("has-banner");
+  }
+}
+
+// ---------------- 공유 (카카오톡 등) ----------------
+const SITE_URL = (() => { try { return location.origin + location.pathname; } catch (e) { return ""; } })();
+
+function ensureKakao() {
+  return new Promise((resolve) => {
+    if (!CFG.KAKAO_JS_KEY) return resolve(false);
+    const init = () => { try { if (!window.Kakao.isInitialized()) window.Kakao.init(CFG.KAKAO_JS_KEY); resolve(true); } catch (e) { resolve(false); } };
+    if (window.Kakao && window.Kakao.isInitialized) return init();
+    if (window.Kakao) return init();
+    const s = document.createElement("script");
+    s.src = "https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js";
+    s.onload = init; s.onerror = () => resolve(false);
+    document.head.appendChild(s);
+  });
+}
+
+async function shareContent(title, text, url) {
+  // 1) 카카오 SDK (KAKAO_JS_KEY가 있을 때 카카오톡 카드로)
+  if (CFG.KAKAO_JS_KEY) {
+    const ok = await ensureKakao();
+    if (ok && window.Kakao && window.Kakao.Share) {
+      try {
+        window.Kakao.Share.sendDefault({
+          objectType: "text",
+          text: `${title}\n\n${text}`,
+          link: { mobileWebUrl: url, webUrl: url },
+        });
+        return;
+      } catch (e) { /* fall through */ }
+    }
+  }
+  // 2) 휴대폰 기본 공유 시트 (카카오톡 선택 가능)
+  if (navigator.share) {
+    try { await navigator.share({ title, text, url }); return; }
+    catch (e) { if (e && e.name === "AbortError") return; }
+  }
+  // 3) 클립보드 복사
+  const full = `${title}\n${text}\n${url}`;
+  try { await navigator.clipboard.writeText(full); alert("공유 내용을 복사했어요. 카카오톡에 붙여넣기 하세요!"); }
+  catch (e) { prompt("아래 내용을 복사해 공유하세요:", full); }
+}
+
+function shareRehearsal(r) {
+  const parts = [];
+  if (r.date) parts.push(`🗓️ ${r.date}${r.time ? " " + formatTime(r.time) : ""}`);
+  if (r.location) parts.push(`📍 ${r.location}`);
+  if ((r.songs || []).length) parts.push(`🎵 ${r.songs.join(", ")}`);
+  if ((r.attendees || []).length) parts.push(`👥 ${r.attendees.join(", ")}`);
+  shareContent("Seoul Bremen 합주 일정", parts.join("\n"), SITE_URL + "#rehearsals");
+}
+function shareEvent(ev) {
+  const parts = [];
+  if (ev.date) parts.push(`📅 ${ev.date}${ev.time ? " " + ev.time : ""}`);
+  if (ev.location) parts.push(`📍 ${ev.location}`);
+  if (ev.notes) parts.push(ev.notes);
+  shareContent(`[${ev.type || "일정"}] ${ev.title || "이벤트"}`, parts.join("\n"), SITE_URL + "#schedule");
 }
 
 function adminCtrls(type, row) {
@@ -477,7 +541,10 @@ function renderRehearsals() {
           ${attendees ? `<div class="attendees"><div class="label">참석 (${r.attendees.length}명)</div>${attendees}</div>` : ""}
           ${costBlock(r)}
           ${r.notes ? `<div class="notes">${escapeHtml(r.notes)}</div>` : ""}
-          ${calendarUrl(r) ? `<div class="cal-row"><a class="cal-btn" href="${escapeHtml(calendarUrl(r))}" target="_blank" rel="noopener">📅 캘린더에 추가</a></div>` : ""}
+          <div class="cal-row">
+            ${calendarUrl(r) ? `<a class="cal-btn" href="${escapeHtml(calendarUrl(r))}" target="_blank" rel="noopener">📅 캘린더에 추가</a>` : ""}
+            <button class="cal-btn share-btn" data-share-rehearsal="${r._row}">📤 공유</button>
+          </div>
           ${adminCtrls("rehearsal", r._row)}
         </div>
       </div>
@@ -560,7 +627,10 @@ function renderEvents() {
             ${ev.location ? `<span>📍 ${escapeHtml(ev.location)}</span>` : ""}
           </div>
           ${ev.notes ? `<div class="notes">${escapeHtml(ev.notes)}</div>` : ""}
-          ${cal ? `<div class="cal-row"><a class="cal-btn" href="${escapeHtml(cal)}" target="_blank" rel="noopener">📅 캘린더에 추가</a></div>` : ""}
+          <div class="cal-row">
+            ${cal ? `<a class="cal-btn" href="${escapeHtml(cal)}" target="_blank" rel="noopener">📅 캘린더에 추가</a>` : ""}
+            <button class="cal-btn share-btn" data-share-event="${ev._row}">📤 공유</button>
+          </div>
           ${adminCtrls("event", ev._row)}
         </div>
       </div>
@@ -970,6 +1040,7 @@ function renderAll() {
   document.getElementById("stat-rehearsals").textContent = STATE.rehearsals.length;
   document.getElementById("stat-songs").textContent = STATE.songs.length;
   document.getElementById("stat-photos").textContent = STATE.photos.filter((p) => p.src).length;
+  setBanner();
   bindItemControls();
 }
 
@@ -1205,6 +1276,18 @@ function bindItemControls() {
         await refresh();
       } catch (err) { alert("삭제 실패: " + err.message); }
     }));
+  document.querySelectorAll("[data-share-rehearsal]").forEach((b) =>
+    b.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const r = STATE.rehearsals.find((x) => String(x._row) === String(b.dataset.shareRehearsal));
+      if (r) shareRehearsal(r);
+    }));
+  document.querySelectorAll("[data-share-event]").forEach((b) =>
+    b.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const ev = STATE.events.find((x) => String(x._row) === String(b.dataset.shareEvent));
+      if (ev) shareEvent(ev);
+    }));
   document.querySelectorAll("[data-sess-song]").forEach((sel) =>
     sel.addEventListener("change", async () => {
       const id = sel.dataset.sessSong, part = sel.dataset.sessPart, val = sel.value;
@@ -1324,7 +1407,6 @@ function setupStatic() {
 
 (async function init() {
   setupStatic();
-  renderHero(CLUB_DEFAULT, { rehearsals: 0, songs: 0, photos: 0 });
 
   // 사진 올리기 버튼: 앱스 스크립트가 연결돼 있으면 누구나 사용 가능
   if (CFG.SCRIPT_URL) document.getElementById("photo-upload-btn").hidden = false;

--- a/seoulbremen/config.js
+++ b/seoulbremen/config.js
@@ -24,4 +24,13 @@ window.SEOUL_BREMEN_CONFIG = {
   SCRIPT_URL: "https://script.google.com/macros/s/AKfycbwZKbr67XQypZieBQq8K9Ox4Vnfn0JNhiPxSsS-bALJorwqsr-fAuverT9vo58MYYjVVQ/exec",
   // 사진 공유 드라이브 폴더 ID — 갤러리에 "드라이브 폴더" 바로가기 표시용
   DRIVE_FOLDER_ID: "11oWl1JSrWjNeJeUeFvaKu_Q1eG792Vjk",
+
+  // ----- 배너 / 공유 -----
+  // 상단 배너 사진 URL (구글 드라이브 공유 링크 OK). 비우면 갤러리 첫 사진을 사용.
+  BANNER_URL: "",
+  // (선택) 카카오 JavaScript 키 — 넣으면 공유 시 카카오톡 카드 형태로 보냄.
+  //   비우면 휴대폰 기본 공유(카카오톡 선택 가능) / 링크 복사로 동작.
+  //   Kakao Developers → 내 앱 → 앱 키 → JavaScript 키
+  KAKAO_JS_KEY: "",
 };
+

--- a/seoulbremen/index.html
+++ b/seoulbremen/index.html
@@ -3,11 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>서울 브레멘 🎵</title>
-  <meta name="description" content="서울 브레멘 - 합주 동아리. 합주 일정, 연습곡, 활동 사진 아카이브." />
-  <meta property="og:title" content="서울 브레멘 🎵" />
-  <meta property="og:description" content="합주 일정 · 연습곡 · 활동 사진을 한 곳에서" />
+  <title>Seoul Bremen 🎵</title>
+  <meta name="description" content="Seoul Bremen — 합주 일정, 스케줄, 연습곡, 사진" />
+  <meta property="og:title" content="Seoul Bremen 🎵" />
+  <meta property="og:description" content="합주 일정 · 스케줄 · 연습곡 · 사진을 한 곳에서" />
   <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://minhjih.github.io/seoulbremen/banner.jpg" />
+  <meta name="twitter:card" content="summary_large_image" />
   <link rel="preconnect" href="https://cdn.jsdelivr.net" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.css" />
   <link rel="stylesheet" href="styles.css" />
@@ -28,11 +30,9 @@
     </div>
   </nav>
 
-  <header class="hero">
-    <div class="container">
-      <h1 id="club-name">서울 <span class="accent">브레멘</span></h1>
-      <p class="tagline" id="tagline"></p>
-      <p class="desc" id="desc"></p>
+  <header class="hero" id="hero">
+    <div class="container hero-inner">
+      <h1 class="hero-title">Seoul Bremen</h1>
       <div class="hero-meta">
         <div class="stat"><div class="num" id="stat-rehearsals">0</div><div class="label">합주</div></div>
         <div class="stat"><div class="num" id="stat-songs">0</div><div class="label">연습곡</div></div>

--- a/seoulbremen/styles.css
+++ b/seoulbremen/styles.css
@@ -93,21 +93,28 @@ main .page { border-top: none !important; padding-top: 28px; }
 
 /* ===== Hero ===== */
 .hero {
-  padding: 44px 0 32px;
+  padding: 72px 0 56px;
   text-align: center;
-  background: radial-gradient(
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-color: var(--bg-soft);
+  background-image: radial-gradient(
       120% 90% at 50% -10%,
       rgba(123, 108, 246, 0.18),
       transparent 60%
     ),
     radial-gradient(80% 60% at 80% 0%, rgba(255, 184, 77, 0.12), transparent 60%);
 }
-.hero h1 {
-  font-size: clamp(2.4rem, 7vw, 4rem);
+.hero.has-banner { border-bottom: 1px solid var(--border); }
+.hero-title {
+  font-size: clamp(2.6rem, 9vw, 4.4rem);
   font-weight: 900;
-  letter-spacing: -0.03em;
-  line-height: 1.05;
+  letter-spacing: -0.02em;
+  line-height: 1.02;
+  font-family: "Pretendard", sans-serif;
 }
+.hero.has-banner .hero-title { text-shadow: 0 2px 16px rgba(0, 0, 0, 0.5); }
 .hero h1 .accent { color: var(--accent); }
 .hero .tagline {
   margin-top: 16px;
@@ -261,7 +268,9 @@ section { padding: 56px 0; border-top: 1px solid var(--border); }
 .rehearsal .cost-split { color: var(--green); font-weight: 600; }
 .rehearsal .cost-split b { font-size: 1.05rem; }
 
-.rehearsal .cal-row { margin-top: 12px; }
+.rehearsal .cal-row { margin-top: 12px; display: flex; gap: 8px; flex-wrap: wrap; }
+.cal-btn.share-btn { cursor: pointer; }
+.cal-btn.share-btn:hover { border-color: var(--accent-2); color: var(--accent-2); }
 .cal-btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## 변경
1. **히어로 배너**: 장황한 설명 문구 제거 → **`Seoul Bremen`** 타이틀 + **배경 사진 배너**.
   - `config.BANNER_URL`(구글 드라이브 링크 OK)로 지정, 비우면 **갤러리 첫 사진** 자동 사용.
2. **일정 공유(카카오톡)**: 합주/스케줄 항목에 **📤 공유** 버튼.
   - `KAKAO_JS_KEY` 있으면 카카오톡 카드로, 없으면 **휴대폰 기본 공유 시트**(카카오톡 선택 가능) → 안 되면 클립보드 복사.
   - 공유 내용: 날짜/시간/장소/곡·참석 등 + 해당 페이지 링크.
3. OG 메타 갱신(카카오톡 링크 붙여넣기 미리보기용).
4. config에 `BANNER_URL`, `KAKAO_JS_KEY` 추가.

https://claude.ai/code/session_01KC7AkYYRndPgM83qJz4tsj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KC7AkYYRndPgM83qJz4tsj)_