### PR TITLE
대기 화면에 '해당 계좌로 N원 입금해주세요' 안내 추가

### DIFF
--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -193,10 +193,12 @@ function renderOrderCard(o) {
         <div class="row"><span class="k">입금완료 신고</span><span class="v" style="color:var(--ok)">${new Date(o.paid_at).toLocaleString("ko-KR")}</span></div>
         <div class="row"><span class="k">상태</span><span class="v">관리자 확인 대기중</span></div>
       </div>
+      ${depositReminder(o.amount)}
       <div class="notice">입금 확인은 <b>수동</b>이라 <b>최대 하루</b> 정도 걸릴 수 있어요. 확인이 끝나면 이 화면에 <b>입장 QR</b>이 자동으로 떠요. 잠시만 기다려 주세요.</div>
-      <details style="margin-top:10px"><summary class="hint">입금 정보 다시 보기</summary>${paymentInstructionsHTML(o.method, o.amount)}</details>`;
+      <details style="margin-top:10px"><summary class="hint">계좌·QR 다시 보기</summary>${paymentInstructionsHTML(o.method, o.amount)}</details>`;
   } else {
-    body = `<p class="hint">아래 안내로 <b>${won(o.amount)}</b> 보낸 뒤 <b>‘입금 완료’</b>를 눌러주세요.<br/>동명이인 구분을 위해 완료 시각이 기록됩니다.</p>
+    body = `${depositReminder(o.amount)}
+      <p class="hint">보낸 뒤 <b>‘입금 완료’</b>를 눌러주세요. 동명이인 구분을 위해 완료 시각이 기록됩니다.</p>
       ${paymentInstructionsHTML(o.method, o.amount)}
       <button class="btn" data-pay="${o.id}">① 입금하기</button>
       <button class="btn ghost" data-paid="${o.id}" id="paidBtn-${o.id}" disabled>② 입금 완료했어요</button>
@@ -264,6 +266,18 @@ function wireOrderActions(orders) {
 
 // ---------------- 결제 안내 ----------------
 const methodLabel = (m) => (m === "qr" ? "뱅킹앱 송금" : m === "cash" ? "현금" : "계좌이체");
+
+// 입금 전이면 어디로 얼마 보내야 하는지 명확히 (QR 발급 전까지 계속 노출)
+function depositReminder(amount) {
+  const B = CFG.BANK || {};
+  const acct = B.bank && B.account
+    ? `${esc(B.bank)} ${esc(B.account)}${B.holder ? ` (${esc(B.holder)})` : ""}`
+    : "";
+  return `<div class="notice" style="border-left-color:var(--gold);background:rgba(230,165,60,.12)">
+      아직 입금 전이라면 <b>${acct}</b> 로 <b>${won(amount)}</b> 입금해 주세요.<br/>
+      입금이 확인되면 이 화면에 <b>입장 QR</b>이 자동으로 떠요.
+    </div>`;
+}
 
 function paymentInstructionsHTML(method, amount) {
   const B = CFG.BANK || {};


### PR DESCRIPTION
예매 후 입장 QR이 발급되기 전(대기) 화면에서, 아직 입금 안 한 관객이 헷갈리지 않도록 **어디로 얼마 입금해야 하는지**를 항상 명확히 보여줍니다.

- 입금 전 상태 + 입금완료 신고 후(관리자 확인 대기) 상태 **모두**에 안내 노출:
  > 아직 입금 전이라면 **토스뱅크 1002-7029-2183 (최재현)** 로 **7,000원** 입금해 주세요. 입금이 확인되면 이 화면에 **입장 QR**이 자동으로 떠요.
- `config.js`의 `BANK`(은행·계좌·예금주)와 주문 금액을 그대로 사용 → 계좌 바뀌면 자동 반영
- `app.js`만 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZSE6K6bvp7cXWPpodjZRV)_