### PR TITLE
발급 티켓에 QR 코드(UUID) 텍스트 표시 (스캔 실패 대비)

### DIFF
--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -147,6 +147,7 @@ async function renderLoggedIn(user) {
   }
   area.innerHTML = html;
   wireUserbar();
+  wireCopy(area);
 
   if (active.length) {
     // QR 그리기
@@ -181,6 +182,7 @@ function renderOrderCard(o) {
         <div class="qr-box" id="qr-${o.id}"></div>
         <div class="qr-meta">${esc(o.buyer_name)} · ${o.quantity}인</div>
         <div class="qr-note">입장 시 이 QR을 확인자에게 보여주세요.<br/>확인되면 QR은 자동으로 만료됩니다. (화면 밝기 최대 권장)</div>
+        <div class="qr-code">코드 <code>${esc(o.qr_token)}</code> <button class="copy" data-copy="${esc(o.qr_token)}">복사</button><br/><span style="color:var(--dim)">스캔이 안 되면 이 코드를 확인자에게 보여주세요.</span></div>
       </div>`;
   } else if (o.status === "used") {
     body = `<div class="center" style="padding:18px 0 6px">

--- a/ticket_2026_Janyeol/styles.css
+++ b/ticket_2026_Janyeol/styles.css
@@ -226,6 +226,8 @@ select { appearance: none;
 .qr-box img, .qr-box canvas { display: block; }
 .qr-note { color: var(--muted); font-size: 12.5px; margin-top: 10px; line-height: 1.65; }
 .qr-meta { font-family: var(--f-serif); font-style: italic; font-weight: 700; margin-top: 8px; font-size: 19px; color: var(--cream); }
+.qr-code { margin-top: 12px; font-size: 12px; color: var(--muted); line-height: 1.8; }
+.qr-code code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--ink); background: rgba(255,236,224,.07); padding: 3px 8px; border-radius: 8px; letter-spacing: .02em; word-break: break-all; font-size: 11.5px; }
 
 .hint { color: var(--muted); font-size: 13px; margin-top: 8px; line-height: 1.65; }
 .notice { margin-top: 14px; background: rgba(232,165,60,.09); border: 1px solid rgba(232,165,60,.26); border-left: 3px solid var(--warn); border-radius: 10px; padding: 11px 13px; font-size: 12.5px; color: #e9c9a6; line-height: 1.65; text-align: left; }


### PR DESCRIPTION
발급된 입장 QR 아래에 **QR이 담고 있는 코드(UUID)** 를 함께 표시합니다. 스캐너가 QR을 못 읽을 때 확인자 페이지의 **‘코드 직접 입력’** 으로 대체할 수 있어요.

- 확정 티켓 카드: QR + `qr_token` 값(모노스페이스) + **복사** 버튼 + "스캔이 안 되면 이 코드를 확인자에게 보여주세요" 안내
- 주문 카드 내 복사 버튼(계좌·코드) 이벤트 바인딩 연결(`wireCopy`) — 대기 카드의 계좌 복사 버튼도 함께 동작
- `app.js`(+2), `styles.css`(+2)만 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZSE6K6bvp7cXWPpodjZRV)_