### PR TITLE
구글 로그인 네이티브화(supabase.co 노출 제거) + 송금 QR 링크/문구

### DIFF
--- a/ticket_2026_Janyeol/SETUP.md
+++ b/ticket_2026_Janyeol/SETUP.md
@@ -44,6 +44,15 @@ Supabase 대시보드 → **Authentication → Sign In / Providers → Google**
 
 > 이미 구글 로그인이 켜져 있다면 Redirect URLs 에 위 주소만 추가하면 됩니다.
 
+#### (권장) supabase.co 화면 안 보이게 — 네이티브 구글 로그인
+
+기본 방식은 로그인 중간에 `xxxx.supabase.co` 도메인을 잠깐 거쳐서 낯설게 보일 수 있어요.
+Google Cloud의 **웹 클라이언트 ID**(`xxxxx.apps.googleusercontent.com`)를 `config.js` 의
+`GOOGLE_CLIENT_ID` 에 넣으면, **우리 사이트에서 바로 구글 계정 선택창**이 떠서 supabase.co 가 노출되지 않습니다.
+
+- 조건: Google Cloud → 해당 OAuth 클라이언트 → **승인된 자바스크립트 원본**에 `https://minhjih.github.io` 가 있어야 함(위에서 이미 설정).
+- `GOOGLE_CLIENT_ID` 를 비워두면 기존 리다이렉트 방식으로 폴백(로그인은 됨).
+
 ### 2) `config.js` 채우기
 
 `config.js` 를 열어 실제 정보로 수정 → 깃허브에 커밋/푸시:

--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -329,7 +329,8 @@ function paymentInstructionsHTML(method, amount) {
   if (method === "qr") {
     return `<div class="pay-box">
       ${T.qrImage ? `<div class="center"><img src="${esc(T.qrImage)}" alt="송금 QR" style="max-width:230px;border-radius:12px" onerror="this.parentNode.style.display='none'"/></div>
-      <p class="hint center">토스·카카오뱅크 등 <b>뱅킹앱으로 이 QR을 스캔</b>해 송금하세요.</p>` : ""}
+      <p class="hint center"><b>휴대폰 카메라로 이 QR을 스캔</b>해 송금하세요.</p>
+      ${T.link ? `<p class="hint center">위 QR에 대한 링크는 <a href="${esc(T.link)}" target="_blank" rel="noopener"><b>여기</b></a> 입니다.</p>` : ""}` : ""}
       <div class="row"><span class="k">은행</span><span class="v">${esc(B.bank || "")}</span></div>
       <div class="row"><span class="k">계좌번호</span><span class="v">${esc(B.account || "")}
         <button class="copy" data-copy="${esc(acct)}">복사</button></span></div>

--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -99,15 +99,22 @@ function renderLoggedOut() {
         <li>당일날 QR을 제시해주시면 입장할 수 있어요.</li>
         <li>입금 확인은 <b>수동</b>으로 진행되어, 확인까지 <b>최대 하루</b> 정도 걸릴 수 있어요.</li>
       </ul>
-      <button class="btn google" id="loginBtn">
+      <div id="gsiWrap" class="center" style="display:flex;justify-content:center;min-height:44px;margin-top:16px"></div>
+      <button class="btn google" id="loginBtn" style="display:none">
+
         <svg viewBox="0 0 48 48"><path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9 3.6l6.7-6.7C35.6 2.6 30.1 0 24 0 14.6 0 6.4 5.4 2.6 13.2l7.8 6.1C12.2 13.6 17.6 9.5 24 9.5z"/><path fill="#4285F4" d="M46.1 24.5c0-1.6-.1-3.1-.4-4.5H24v9h12.4c-.5 2.9-2.1 5.3-4.6 7l7.1 5.5c4.2-3.9 6.6-9.6 6.6-16.5z"/><path fill="#FBBC05" d="M10.4 28.3c-.5-1.4-.8-2.9-.8-4.3s.3-3 .8-4.3l-7.8-6.1C.9 16.7 0 20.2 0 24s.9 7.3 2.6 10.4l7.8-6.1z"/><path fill="#34A853" d="M24 48c6.1 0 11.3-2 15-5.5l-7.1-5.5c-2 1.3-4.6 2.1-7.9 2.1-6.4 0-11.8-4.1-13.7-9.8l-7.8 6.1C6.4 42.6 14.6 48 24 48z"/></svg>
         구글 로그인하고 티켓 구매
       </button>
       <div class="err" id="authErr"></div>
     </div>`;
   $("#loginBtn").onclick = login;
+  // 구글 Client ID가 있으면 네이티브(GIS) 버튼, 없으면 리다이렉트 버튼으로 폴백
+  mountGoogle($("#gsiWrap")).then((ok) => {
+    if (!ok) $("#loginBtn").style.display = "";
+  });
 }
 
+// 리다이렉트 방식(폴백): supabase.co 화면을 거침
 async function login() {
   $("#authErr").textContent = "";
   const { error } = await sb.auth.signInWithOAuth({
@@ -115,6 +122,50 @@ async function login() {
     options: { redirectTo: location.href.split("#")[0].split("?")[0] },
   });
   if (error) $("#authErr").textContent = "로그인 오류: " + error.message;
+}
+
+// 네이티브 방식(GIS + ID 토큰): 우리 사이트에서 바로 구글 계정 선택 (supabase.co 노출 X)
+async function sha256hex(s) {
+  const buf = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+  return Array.from(new Uint8Array(buf)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function mountGoogle(container) {
+  const CID = CFG.GOOGLE_CLIENT_ID || "";
+  if (!CID || !container) return false;
+  let tries = 0;
+  while (!(window.google && google.accounts && google.accounts.id) && tries < 30) {
+    await new Promise((r) => setTimeout(r, 150));
+    tries++;
+  }
+  if (!(window.google && google.accounts && google.accounts.id)) return false;
+  try {
+    const rawNonce = `${crypto.randomUUID()}-${crypto.randomUUID()}`;
+    const hashedNonce = await sha256hex(rawNonce);
+    google.accounts.id.initialize({
+      client_id: CID,
+      nonce: hashedNonce,
+      auto_select: false,
+      use_fedcm_for_prompt: true,
+      callback: async (resp) => {
+        $("#authErr").textContent = "";
+        const { error } = await sb.auth.signInWithIdToken({
+          provider: "google",
+          token: resp.credential,
+          nonce: rawNonce,
+        });
+        if (error) $("#authErr").textContent = "로그인 오류: " + error.message;
+      },
+    });
+    container.innerHTML = "";
+    google.accounts.id.renderButton(container, {
+      type: "standard", theme: "filled_blue", size: "large",
+      text: "continue_with", shape: "pill", logo_alignment: "center",
+    });
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 // ---------------- 렌더: 로그인 후 ----------------

--- a/ticket_2026_Janyeol/config.js
+++ b/ticket_2026_Janyeol/config.js
@@ -18,6 +18,11 @@ window.JANYEOL_CONFIG = {
   // 관리자/확인자 백엔드 (엣지 함수 이름) — 비밀번호는 Supabase DB(tk_config)에만 저장
   DESK_FUNCTION: "janyeol-desk",
 
+  // 구글 로그인 — Google Cloud의 웹 OAuth "클라이언트 ID"(xxx.apps.googleusercontent.com)를 넣으면
+  // 우리 사이트에서 바로 구글 계정 선택창이 뜹니다(중간에 supabase.co 도메인 노출 X).
+  // 비워두면 기존 리다이렉트 방식으로 동작(로그인은 되지만 supabase.co 화면을 거침).
+  GOOGLE_CLIENT_ID: "",
+
   // ----- 공연 정보 -----
   EVENT: {
     title: "잔열",

--- a/ticket_2026_Janyeol/config.js
+++ b/ticket_2026_Janyeol/config.js
@@ -37,10 +37,12 @@ window.JANYEOL_CONFIG = {
     holder: "최재현",
     tossBankCode: "TOSS",
   },
-  // 뱅킹앱 송금 QR (토스·카카오뱅크 등에서 스캔). 계좌는 위 BANK 사용.
+  // 송금 QR (휴대폰 카메라로 스캔). 계좌는 위 BANK 사용.
   // img/transfer-qr.png 파일을 넣으면 QR 이미지가 표시됩니다(없어도 계좌번호로 동작).
+  // link: 그 QR이 담고 있는 링크(클릭 시 팝업으로 열림).
   TRANSFER: {
     qrImage: "img/transfer-qr.png",
+    link: "https://free4qr.com/qr-result#b=092&a=1002-7029-2183&h=%EC%B5%9C%EC%9E%AC%ED%98%84",
   },
 
   // ----- 포스터 이미지 (img/ 폴더에 넣기) -----

--- a/ticket_2026_Janyeol/index.html
+++ b/ticket_2026_Janyeol/index.html
@@ -91,6 +91,7 @@
 
   <div id="toast" class="toast"></div>
 
+  <script src="https://accounts.google.com/gsi/client" async></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="https://cdn.jsdelivr.net/gh/davidshimjs/qrcodejs/qrcode.min.js"
     onerror="var s=document.createElement('script');s.src='https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js';document.head.appendChild(s);"></script>


### PR DESCRIPTION
## 1) 구글 로그인에서 `supabase.co` 안 보이게 (신뢰도 개선)
로그인 시 뜨던 `gppwawgyoysctikujmed.supabase.co(으)로 이동` 화면이 낯설게 보이는 문제를, **Google 네이티브 로그인(GIS + `signInWithIdToken`)** 으로 해결합니다.
- `config.js`의 **`GOOGLE_CLIENT_ID`** 에 웹 클라이언트 ID를 넣으면 → **우리 사이트에서 바로 구글 계정 선택창**(중간 supabase.co 화면 없음, Google 공식 버튼)
- 비워두면 기존 리다이렉트(`signInWithOAuth`)로 **자동 폴백** → 지금 동작 그대로 유지(안 깨짐)
- `index.html`에 `accounts.google.com/gsi/client` 로드, nonce는 원문/해시 분리 처리
- 조건: Google Cloud OAuth 클라이언트의 **승인된 자바스크립트 원본**에 `https://minhjih.github.io` (기설정)

## 2) 송금 QR 문구/링크
- "뱅킹앱으로 스캔" → **"휴대폰 카메라로 스캔"**
- QR 아래 **"위 QR에 대한 링크는 여기입니다"** → 클릭 시 **새 탭**으로 열림 (`TRANSFER.link`)

## 적용 안내
`GOOGLE_CLIENT_ID` 를 채우면 supabase.co 없는 로그인으로 전환됩니다. SETUP.md에 방법 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)