### PR TITLE
레이아웃: 지도(Location)를 타임테이블 위로

### DIFF
--- a/ticket_2026_Janyeol/index.html
+++ b/ticket_2026_Janyeol/index.html
@@ -55,13 +55,6 @@
     <!-- 내 티켓 / 로그인 / 구매 -->
     <div id="ticketArea"></div>
 
-    <!-- 큐시트 -->
-    <div class="eyebrow">Timetable</div>
-    <div class="card">
-      <div class="poster-frame" style="margin-bottom:18px"><img id="posterCue" class="poster" alt="잔열 큐시트" /></div>
-      <div id="cueList"></div>
-    </div>
-
     <!-- 오시는 길 (지도) -->
     <div class="eyebrow">Location</div>
     <div class="card">
@@ -82,6 +75,13 @@
       </div>
       <p class="hint" style="margin-top:10px; font-size:12px; color:var(--gold);">⚠️ *001클럽(홍대)과 다른 장소입니다 (마포구 월드컵로 140
         지하1층)</p>
+    </div>
+
+    <!-- 큐시트 -->
+    <div class="eyebrow">Timetable</div>
+    <div class="card">
+      <div class="poster-frame" style="margin-bottom:18px"><img id="posterCue" class="poster" alt="잔열 큐시트" /></div>
+      <div id="cueList"></div>
     </div>
 
     <div class="footer">


### PR DESCRIPTION
메인 페이지에서 **오시는 길(Location/지도) 섹션을 Timetable 섹션 위로** 이동했습니다.

- 순서: 티켓 구매 → **Location(지도)** → Timetable(큐시트)
- `index.html` 섹션 순서만 변경(내용/스타일 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZSE6K6bvp7cXWPpodjZRV)_