### PR TITLE
대기 카드 정리 + iOS 티켓 저장 수정 + 태양 애니메이션 복원

### DIFF
--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -300,7 +300,7 @@ function renderOrderCard(o) {
         <div class="qr-note">입금이 확인되면 QR이 여기에 자동으로 떠요.</div>
       </div>
       ${depositReminder(o.amount)}
-      ${paymentInstructionsHTML(o.method, o.amount)}
+      ${accountBoxHTML(o.amount)}
       <div class="notice">입금 확인은 <b>수동</b>이라 <b>최대 하루</b> 정도 걸릴 수 있어요. 확인되면 이 화면에 <b>입장 QR</b>이 자동으로 떠요.</div>`;
   }
   return `<div class="card">
@@ -360,6 +360,19 @@ function depositReminder(amount) {
   return `<div class="notice" style="border-left-color:var(--gold);background:rgba(230,165,60,.12)">
       아직 입금 전이라면 <b>${acct}</b> 로 <b>${won(amount)}</b> 입금해 주세요.<br/>
       입금이 확인되면 이 화면에 <b>입장 QR</b>이 자동으로 떠요.
+    </div>`;
+}
+
+// 계좌 정보만 (QR/버튼 없이) — 대기 카드에서 사용
+function accountBoxHTML(amount) {
+  const B = CFG.BANK || {};
+  const acct = (B.account || "").replace(/[^0-9]/g, "");
+  return `<div class="pay-box">
+      <div class="row"><span class="k">은행</span><span class="v">${esc(B.bank || "")}</span></div>
+      <div class="row"><span class="k">계좌번호</span><span class="v">${esc(B.account || "")}
+        <button class="copy" data-copy="${esc(acct)}">복사</button></span></div>
+      ${B.holder ? `<div class="row"><span class="k">예금주</span><span class="v">${esc(B.holder)}</span></div>` : ""}
+      <div class="row"><span class="k">보낼 금액</span><span class="v" style="color:var(--gold)">${won(amount)}</span></div>
     </div>`;
 }
 

--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -221,7 +221,11 @@ async function renderLoggedIn(user) {
   if (active.length) {
     // QR 그리기
     active.forEach((o) => {
-      if (o.status === "confirmed" && o.qr_token) drawQR(`qr-${o.id}`, o.qr_token);
+      if (o.status === "confirmed" && o.qr_token) {
+        drawQR(`qr-${o.id}`, o.qr_token);
+        // 티켓 이미지를 미리 생성 → iOS에서 버튼 탭 시 공유(사진 저장)가 제스처 안에서 즉시 동작
+        setTimeout(() => preparePass(`pass-${o.id}`), 300);
+      }
     });
     $("#addMore").onclick = () => {
       $("#addMore").classList.add("hidden");
@@ -323,25 +327,79 @@ function drawQR(elId, text) {
   });
 }
 
-async function saveTicketImage(passElementId, buyerName) {
+const PASS_BLOBS = {};
+
+async function renderPassBlob(passElementId) {
   const passEl = document.getElementById(passElementId);
-  if (!passEl) return;
+  if (!passEl || !window.html2canvas) return null;
+  const canvas = await window.html2canvas(passEl, {
+    scale: 3, // 고해상도 저장
+    backgroundColor: "#f4f4f4",
+    useCORS: true,
+    logging: false,
+  });
+  return await new Promise((res) => canvas.toBlob(res, "image/png"));
+}
+
+// 티켓 이미지를 미리 만들어 둠(공유 제스처 보존용)
+async function preparePass(passElementId) {
   try {
-    toast("티켓 이미지 생성 중…");
-    const canvas = await window.html2canvas(passEl, {
-      scale: 3, // 고해상도 저장
-      backgroundColor: "#f4f4f4",
-      useCORS: true,
-      logging: false,
-    });
-    const image = canvas.toDataURL("image/png");
-    const link = document.createElement("a");
-    link.href = image;
-    link.download = `티켓_${buyerName || "잔열"}.png`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    toast("티켓 사진이 저장되었습니다!");
+    const blob = await renderPassBlob(passElementId);
+    if (blob) PASS_BLOBS[passElementId] = blob;
+  } catch (_) { /* 저장 시 재생성 */ }
+}
+
+const isIOS = () =>
+  /iP(hone|ad|od)/.test(navigator.userAgent) ||
+  (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+
+async function saveTicketImage(passElementId, buyerName) {
+  const fileName = `티켓_${buyerName || "잔열"}.png`;
+  try {
+    // 1) 미리 만든 이미지가 있으면, 제스처 안에서 바로 공유(iOS '이미지 저장')
+    const ready = PASS_BLOBS[passElementId];
+    if (ready && navigator.canShare) {
+      const file = new File([ready], fileName, { type: "image/png" });
+      if (navigator.canShare({ files: [file] })) {
+        try { await navigator.share({ files: [file], title: "잔열 티켓" }); return; }
+        catch (err) { if (err && err.name === "AbortError") return; }
+      }
+    }
+
+    // 2) 준비 안 됐으면 지금 생성
+    let blob = ready;
+    if (!blob) {
+      toast("티켓 이미지 생성 중…");
+      blob = await renderPassBlob(passElementId);
+      if (blob) PASS_BLOBS[passElementId] = blob;
+    }
+    if (!blob) throw new Error("이미지 변환 실패");
+    const url = URL.createObjectURL(blob);
+
+    // 3) 데스크탑/안드로이드: a[download]
+    if (!isIOS() && "download" in document.createElement("a")) {
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      setTimeout(() => URL.revokeObjectURL(url), 6000);
+      toast("티켓 사진이 저장되었습니다!");
+      return;
+    }
+
+    // 4) iOS 폴백: 공유가 막힌 경우 새 탭에 이미지 → 길게 눌러 저장
+    const w = window.open();
+    if (w) {
+      w.document.write(
+        `<title>잔열 티켓</title><body style="margin:0;background:#0a0605;color:#fff;font-family:-apple-system,system-ui,sans-serif;text-align:center;padding:16px">` +
+        `<img src="${url}" alt="잔열 티켓" style="width:100%;max-width:520px;border-radius:12px"/>` +
+        `<p style="padding:14px;font-size:15px">이미지를 <b>길게 눌러</b> ‘사진에 저장’을 선택하세요.</p></body>`
+      );
+    } else {
+      location.href = url; // 팝업 차단 시
+    }
   } catch (e) {
     console.error("티켓 저장 실패:", e);
     toast("저장 실패: 다시 시도해주세요");

--- a/ticket_2026_Janyeol/index.html
+++ b/ticket_2026_Janyeol/index.html
@@ -27,9 +27,14 @@
   <div class="sun-flare" aria-hidden="true"></div>
   <div class="vignette" aria-hidden="true"></div>
   <svg class="svg-defs" aria-hidden="true">
-    <filter id="heat" x="-25%" y="-25%" width="150%" height="150%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.010 0.016" numOctaves="2" seed="7" result="n" />
-      <feDisplacementMap in="SourceGraphic" in2="n" scale="30" xChannelSelector="R" yChannelSelector="G" />
+    <filter id="heat" x="-35%" y="-35%" width="170%" height="170%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.009 0.014" numOctaves="2" seed="7" result="n">
+        <animate attributeName="baseFrequency" dur="15s"
+          values="0.009 0.014;0.015 0.023;0.008 0.017;0.009 0.014" repeatCount="indefinite" />
+      </feTurbulence>
+      <feDisplacementMap in="SourceGraphic" in2="n" xChannelSelector="R" yChannelSelector="G" scale="34">
+        <animate attributeName="scale" dur="9s" values="24;46;30;24" repeatCount="indefinite" />
+      </feDisplacementMap>
     </filter>
   </svg>
 

--- a/ticket_2026_Janyeol/styles.css
+++ b/ticket_2026_Janyeol/styles.css
@@ -61,17 +61,46 @@ a { color: var(--gold); text-underline-offset: 3px; }
   background: radial-gradient(circle at 50% 46%,
     #ffcf88 0%, #ff8f2c 12%, #f2521a 30%, #c22e0e 48%, #7c1c06 64%, rgba(70,14,4,0) 74%);
   filter: blur(3px) url(#heat); opacity: .66;
+  animation: sunMorph 20s ease-in-out infinite, sunBreathe 7.5s ease-in-out infinite;
+  will-change: transform, border-radius;
 }
 .sun::after {
   content: ""; position: absolute; inset: -18%; border-radius: inherit;
-  background: radial-gradient(circle at 50% 48%, rgba(255,95,26,.34) 0%, rgba(226,58,16,0) 62%);
+  background: radial-gradient(circle at 50% 48%, rgba(255,95,26,.4) 0%, rgba(226,58,16,0) 62%);
   filter: blur(34px);
+  animation: sunFlare 9s ease-in-out infinite;
+  will-change: transform, opacity;
 }
 .sun-flare {
   position: absolute; left: 50%; top: 4vh; transform: translateX(-50%);
   width: min(100vw, 900px); height: 78vh; z-index: -2; pointer-events: none;
   background: radial-gradient(58% 76% at 50% 0%, rgba(255,80,20,.2), rgba(226,58,16,0) 72%);
   filter: blur(22px) url(#heat); opacity: .7;
+  animation: flareSweep 13s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+@keyframes sunMorph {
+  0%, 100% { border-radius: 47% 53% 50% 50% / 52% 48% 52% 48%; }
+  25% { border-radius: 54% 46% 56% 44% / 45% 55% 46% 54%; }
+  50% { border-radius: 44% 56% 47% 53% / 56% 44% 55% 45%; }
+  75% { border-radius: 52% 48% 52% 48% / 48% 53% 45% 55%; }
+}
+@keyframes sunBreathe {
+  0%, 100% { transform: translateX(-50%) scale(1); opacity: .6; }
+  50% { transform: translateX(-50%) scale(1.055); opacity: .82; }
+}
+/* 코로나 플레어: 불규칙하게 '터지듯' 밝아졌다 사그라듦 */
+@keyframes sunFlare {
+  0%, 100% { transform: scale(1); opacity: .45; }
+  18% { transform: scale(1.16); opacity: .95; }
+  32% { transform: scale(1.03); opacity: .55; }
+  58% { transform: scale(1.24); opacity: 1; }
+  74% { transform: scale(1.06); opacity: .6; }
+}
+@keyframes flareSweep {
+  0%, 100% { opacity: .5; transform: translateX(-50%) scaleY(1); }
+  50% { opacity: .9; transform: translateX(-50%) scaleY(1.09); }
 }
 .vignette {
   position: fixed; inset: 0; z-index: -1; pointer-events: none;
@@ -339,6 +368,6 @@ select { appearance: none;
 
 @media (min-width: 700px) { .sun { top: 0; } }
 @media (prefers-reduced-motion: reduce) {
-  .sun, .sun::after { animation: none !important; }
+  .sun, .sun::after, .sun-flare { animation: none !important; }
   .sun { filter: blur(3px); }
 }


### PR DESCRIPTION
아직 머지 안 된 브랜치라 세 가지가 함께 들어있습니다.

## 1) 대기 카드: 송금 QR 제거, 계좌만
- "입장 QR 대기중" 카드에서 헷갈리는 송금용 QR/스캔문구/링크버튼 제거 → **은행·계좌번호(복사)·예금주·보낼금액**만 표시

## 2) iOS 티켓 저장 안 되던 버그 수정
- 원인: `<a download>` 방식은 **iOS Safari가 무시**해서 "보기/다운로드" 눌러도 아무 일도 안 일어남
- 수정: **Web Share API(파일 공유 → ‘이미지 저장’)** 로 전환. iOS는 사용자 탭 제스처 안에서 공유해야 하므로, 확정 티켓 렌더 시 이미지를 **미리 생성(preparePass)** 해 두고 버튼 탭 시 즉시 공유
- 폴백: 안드로이드/데스크탑은 `a[download]`, iOS 공유 불가 환경은 새 탭에 이미지 표시(길게 눌러 저장)

## 3) 태양 배경 애니메이션 복원
- 머지 과정에서 사라졌던 애니메이션을 되살림: 블롭 모핑 + 브리딩(맥동) + **코로나 플레어 버스트**(불규칙하게 터지듯) + SVG `feTurbulence`/`displacement` 애니메이션으로 **열-일렁임 강화**
- `prefers-reduced-motion` 대응
- 헤드리스로 두 프레임 캡처해 실제로 움직이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)