### PR TITLE
관리자 일괄 입금확인 + 인스타 공유용 티켓

### DIFF
--- a/ticket_2026_Janyeol/admin.html
+++ b/ticket_2026_Janyeol/admin.html
@@ -52,6 +52,12 @@
         <button class="btn ghost small" id="mailBtn">이메일 알림</button>
         <button class="btn ghost small" id="logoutBtn">잠그기</button>
       </div>
+      <div id="bulkBar" class="hidden" style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;margin:2px 0 10px;padding:10px 12px;border:1px solid var(--line-2);border-radius:12px;background:var(--card)">
+        <label style="font-size:13px;color:var(--muted);display:inline-flex;align-items:center;gap:6px;cursor:pointer">
+          <input type="checkbox" id="selAll" style="width:auto;margin:0" /> 전체 선택
+        </label>
+        <button class="btn small" id="bulkBtn" disabled>선택 <span id="selCount">0</span>건 입금확인 · QR 발급</button>
+      </div>
       <div id="list"></div>
     </div>
 

--- a/ticket_2026_Janyeol/admin.js
+++ b/ticket_2026_Janyeol/admin.js
@@ -87,6 +87,37 @@ function renderList() {
   $("#list").querySelectorAll("[data-act]").forEach((b) => {
     b.onclick = () => act(b.dataset.act, b.dataset.id, b);
   });
+  // 일괄 선택 바 (확인대기 목록에서만)
+  const sels = [...$("#list").querySelectorAll(".ordersel")];
+  const bar = $("#bulkBar");
+  bar.classList.toggle("hidden", sels.length === 0);
+  if (sels.length) {
+    const update = () => {
+      const n = sels.filter((c) => c.checked).length;
+      $("#selCount").textContent = n;
+      $("#bulkBtn").disabled = n === 0;
+      $("#selAll").checked = n > 0 && n === sels.length;
+    };
+    sels.forEach((c) => (c.onchange = update));
+    $("#selAll").onchange = () => { sels.forEach((c) => (c.checked = $("#selAll").checked)); update(); };
+    update();
+  }
+}
+
+async function bulkConfirm() {
+  const ids = [...$("#list").querySelectorAll(".ordersel:checked")].map((c) => c.dataset.id);
+  if (!ids.length) return;
+  if (!confirm(`${ids.length}건을 일괄 입금확인(QR 발급)할까요?`)) return;
+  const btn = $("#bulkBtn");
+  btn.disabled = true;
+  let ok = 0, fail = 0;
+  for (let i = 0; i < ids.length; i++) {
+    $("#selCount").textContent = `${i + 1}/${ids.length} 처리중…`;
+    try { await desk("confirm", { order_id: ids[i] }); ok++; }
+    catch (e) { fail++; }
+  }
+  toast(`일괄 확인: ${ok}건 완료${fail ? ` · ${fail}건 실패` : ""}`);
+  await load();
 }
 
 const SLABEL = {
@@ -111,7 +142,7 @@ function card(o) {
   }
   return `<div class="order">
       <div class="top">
-        <span class="nm">${esc(o.depositor_name || o.buyer_name)} <span style="font-weight:600;color:var(--muted);font-size:13px">· ${o.quantity}인</span></span>
+        <span class="nm">${o.status === "pending" ? `<input type="checkbox" class="ordersel" data-id="${o.id}" style="width:auto;margin:0 8px 0 0;vertical-align:-2px" />` : ""}${esc(o.depositor_name || o.buyer_name)} <span style="font-weight:600;color:var(--muted);font-size:13px">· ${o.quantity}인</span></span>
         <span class="status-pill ${cls}">${lbl}</span>
       </div>
       <div class="meta">
@@ -208,6 +239,7 @@ async function setMailWebhook() {
 // ---------- 이벤트 ----------
 $("#enterBtn").onclick = enter;
 $("#mailBtn").onclick = setMailWebhook;
+$("#bulkBtn").onclick = bulkConfirm;
 $("#pw").addEventListener("keydown", (e) => { if (e.key === "Enter") enter(); });
 $("#refreshBtn").onclick = load;
 $("#csvBtn").onclick = exportCsv;

--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -226,6 +226,7 @@ async function renderLoggedIn(user) {
         drawQR(`qr-${o.id}`, o.qr_token);
         // 티켓 이미지를 미리 생성 → iOS에서 버튼 탭 시 공유(사진 저장)가 제스처 안에서 즉시 동작
         setTimeout(() => preparePass(`pass-${o.id}`), 300);
+        setTimeout(() => preparePass(`share-${o.id}`), 500);
       }
     });
     $("#addMore").onclick = () => {
@@ -287,13 +288,20 @@ function renderOrderCard(o) {
         </div>
       </div>
       
-      <button type="button" class="save-ticket-btn" onclick="saveTicketImage('pass-${o.id}', '${esc(o.buyer_name)}')">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-        티켓 사진으로 저장하기
-      </button>
+      <div class="ticket-btns">
+        <button type="button" class="save-ticket-btn" onclick="saveTicketImage('pass-${o.id}', '${esc(o.buyer_name)}')">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          티켓 저장
+        </button>
+        <button type="button" class="share-ticket-btn" onclick="shareTicketImage('share-${o.id}', '${esc(o.buyer_name)}')">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1.2" fill="currentColor" stroke="none"/></svg>
+          인스타 공유
+        </button>
+      </div>
 
       <div class="qr-note" style="margin-top:12px;">입장 시 위 티켓 QR을 확인자에게 보여주세요.<br/>확인되면 QR은 자동으로 만료됩니다. (화면 밝기 최대 권장)</div>
-      <div class="qr-code">코드 <code>${esc(o.qr_token)}</code> <button class="copy" data-copy="${esc(o.qr_token)}">복사</button></div>`;
+      <div class="qr-code">코드 <code>${esc(o.qr_token)}</code> <button class="copy" data-copy="${esc(o.qr_token)}">복사</button></div>
+      ${shareCardHTML(o)}`;
   } else if (o.status === "used") {
     body = `<div class="center" style="padding:18px 0 6px">
         <div class="qr-meta" style="font-size:26px">입장 완료</div>
@@ -312,6 +320,69 @@ function renderOrderCard(o) {
       <h2>My Ticket · 내 티켓 <span class="status-pill ${cls} pill">${label}</span></h2>
       ${body}
     </div>`;
+}
+
+// 인스타 공유용 카드(오프스크린): 티켓 모양 그대로, QR 자리를 포스터 패널로 대체(QR 없음)
+function shareCardHTML(o) {
+  const poster = (CFG.POSTER && CFG.POSTER.main) || "";
+  return `
+    <div style="position:fixed;left:-10000px;top:0;width:340px;pointer-events:none;" aria-hidden="true">
+      <div class="tech-ticket" id="share-${o.id}">
+        <div class="tech-ticket-head">
+          <div>
+            <div class="tech-ticket-title">${esc(EV.title || "JANYEOL")}</div>
+            <div class="tech-ticket-sub">${esc(EV.dateLabel || "8.29 FRI 5:30PM")} · ${esc(EV.venue || "001 LIVE HALL")}</div>
+          </div>
+          <div class="tech-ticket-badge">SECURED</div>
+        </div>
+        <div class="tech-ticket-grid">
+          <div class="tech-field"><span class="lbl">NAME</span><span class="val">${esc(o.buyer_name)}</span></div>
+          <div class="tech-field"><span class="lbl">QTY</span><span class="val">${o.quantity}인</span></div>
+          <div class="tech-field"><span class="lbl">DATE</span><span class="val">8.29 FRI</span></div>
+          <div class="tech-field"><span class="lbl">VENUE</span><span class="val">${esc(EV.venue || "001 HALL")}</span></div>
+        </div>
+        <div class="share-poster">
+          ${poster ? `<img src="${esc(poster)}" alt="" />` : ""}
+          <div class="share-poster-cap">
+            <div class="l1">SEE YOU THERE</div>
+            <div class="l2">#잔열 · ${esc(EV.dateLabel || "8.29 (금) 5:30PM")} · ${esc(EV.venue || "001 라이브홀")}</div>
+          </div>
+        </div>
+        <div class="tech-ticket-foot"><span>JANYEOL LIVE 2026</span><span>ADMIT ${o.quantity}</span></div>
+      </div>
+    </div>`;
+}
+
+// 인스타 공유(=OS 공유 시트). QR 없는 포스터 카드라 공개해도 안전.
+async function shareTicketImage(shareElementId, buyerName) {
+  const fileName = `잔열티켓_${buyerName || "잔열"}.png`;
+  try {
+    let blob = PASS_BLOBS[shareElementId];
+    if (blob && navigator.canShare) {
+      const file = new File([blob], fileName, { type: "image/png" });
+      if (navigator.canShare({ files: [file] })) {
+        try { await navigator.share({ files: [file], text: "잔열 8.29 (금) 5:30PM · 001 라이브홀 🎫 #잔열" }); return; }
+        catch (err) { if (err && err.name === "AbortError") return; }
+      }
+    }
+    if (!blob) { toast("이미지 생성 중…"); blob = await renderPassBlob(shareElementId); if (blob) PASS_BLOBS[shareElementId] = blob; }
+    if (!blob) throw new Error("이미지 변환 실패");
+    const url = URL.createObjectURL(blob);
+    if (!isIOS() && "download" in document.createElement("a")) {
+      const a = document.createElement("a");
+      a.href = url; a.download = fileName;
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 6000);
+      toast("이미지를 저장했어요! 인스타 스토리에 올려보세요");
+      return;
+    }
+    const w = window.open();
+    if (w) w.document.write(`<title>잔열 티켓</title><body style="margin:0;background:#0a0605;text-align:center"><img src="${url}" style="width:100%;max-width:420px"/><p style="color:#fff;font-family:-apple-system,sans-serif;padding:14px">길게 눌러 저장 후 인스타 스토리에 올려보세요</p></body>`);
+    else location.href = url;
+  } catch (e) {
+    console.error("공유 실패:", e);
+    toast("공유 준비 실패: 다시 시도해주세요");
+  }
 }
 
 function drawQR(elId, text) {

--- a/ticket_2026_Janyeol/styles.css
+++ b/ticket_2026_Janyeol/styles.css
@@ -306,6 +306,24 @@ select { appearance: none;
 }
 .save-ticket-btn:active { transform: scale(.98); background: #e5e5e5; }
 
+.ticket-btns { display: flex; gap: 8px; margin-top: 12px; }
+.ticket-btns > .save-ticket-btn { margin-top: 0; flex: 1; }
+.share-ticket-btn {
+  display: flex; align-items: center; justify-content: center; gap: 7px; flex: 1;
+  padding: 14px; border-radius: var(--r-sm); border: none; cursor: pointer;
+  font-weight: 800; font-size: 13.5px; color: #fff;
+  background: linear-gradient(45deg, #feda75, #fa7e1e 25%, #d62976 55%, #962fbf 80%, #4f5bd5);
+  box-shadow: 0 4px 16px rgba(214,41,118,.35); transition: transform .1s, filter .15s;
+}
+.share-ticket-btn:active { transform: scale(.98); filter: brightness(.95); }
+
+/* 인스타 공유용 카드(오프스크린)의 포스터 패널 — QR 자리 대체 */
+.share-poster { position: relative; border-radius: 8px; overflow: hidden; border: 1px solid #d8d8d8; background: #120806; }
+.share-poster img { width: 100%; height: 210px; object-fit: cover; object-position: center 22%; display: block; }
+.share-poster-cap { position: absolute; left: 0; right: 0; bottom: 0; padding: 12px; background: linear-gradient(180deg, rgba(0,0,0,0), rgba(0,0,0,.82)); color: #fff; font-family: var(--f-mono); }
+.share-poster-cap .l1 { font-size: 14px; font-weight: 700; letter-spacing: 1px; }
+.share-poster-cap .l2 { font-size: 10px; opacity: .9; margin-top: 3px; }
+
 .qr-wrap { text-align: center; }
 .qr-box { display: inline-block; background: #fff; padding: 16px; border-radius: 12px; margin: 12px auto 8px; box-shadow: 0 0 0 1px rgba(255,120,40,.2), 0 18px 44px rgba(226,54,13,.22); }
 .qr-box img, .qr-box canvas { display: block; }


### PR DESCRIPTION
## 변경 요약

두 가지 기능을 추가했습니다.

### 1. 관리자 일괄 입금확인 · QR 발급
- 확인대기 주문마다 **체크박스**가 생기고, 상단에 **"전체 선택"** 바가 표시됩니다.
- 원하는 건들을 체크한 뒤 **"선택 N건 입금확인 · QR 발급"** 버튼 한 번으로 일괄 처리됩니다 (진행상황 표시).
- 이제 주문을 하나씩 확인할 필요 없이 한 번에 처리할 수 있어요.

### 2. 인스타 공유용 티켓 (QR 없는 포스터 버전)
- 발급된 티켓 화면에서 **"티켓 저장"** 옆에 **"인스타 공유"** 버튼을 추가했습니다.
- 지금 티켓 모양 그대로지만 **QR 자리를 포스터 패널로 교체**한 카드(오프스크린 렌더)를 만들어 OS 공유 시트로 내보냅니다.
- 스토리에 바로 올릴 수 있고, **QR이 노출되지 않아 공개해도 안전**합니다.
- iOS에서 버튼 탭 제스처 안에서 즉시 공유되도록 공유 카드도 미리 렌더링(blob 캐시)해 둡니다.

## 변경 파일
- `admin.html` — 일괄 선택 바(전체 선택 + 발급 버튼) 추가
- `admin.js` — 대기 주문 체크박스, 선택 카운트, `bulkConfirm()` 순차 발급
- `app.js` — 티켓 버튼 영역 재구성, `shareCardHTML()` / `shareTicketImage()` 추가, 공유 카드 사전 렌더
- `styles.css` — `.ticket-btns`, `.share-ticket-btn`, `.share-poster` 스타일

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZSE6K6bvp7cXWPpodjZRV)_