### PR TITLE
인스타 공유 티켓: 포스터 crop 정상화 + JPEG 공유

### DIFF
--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -342,7 +342,7 @@ function shareCardHTML(o) {
           <div class="tech-field"><span class="lbl">VENUE</span><span class="val">${esc(EV.venue || "001 HALL")}</span></div>
         </div>
         <div class="share-poster">
-          ${poster ? `<img src="${esc(poster)}" alt="" />` : ""}
+          ${poster ? `<div class="share-poster-img" style="background-image:url('${esc(poster)}')"></div>` : ""}
           <div class="share-poster-cap">
             <div class="l1">SEE YOU THERE</div>
             <div class="l2">#잔열 · ${esc(EV.dateLabel || "8.29 (금) 5:30PM")} · ${esc(EV.venue || "001 라이브홀")}</div>
@@ -355,17 +355,17 @@ function shareCardHTML(o) {
 
 // 인스타 공유(=OS 공유 시트). QR 없는 포스터 카드라 공개해도 안전.
 async function shareTicketImage(shareElementId, buyerName) {
-  const fileName = `잔열티켓_${buyerName || "잔열"}.png`;
+  const fileName = `잔열티켓_${buyerName || "잔열"}.jpg`;
   try {
     let blob = PASS_BLOBS[shareElementId];
     if (blob && navigator.canShare) {
-      const file = new File([blob], fileName, { type: "image/png" });
+      const file = new File([blob], fileName, { type: "image/jpeg" });
       if (navigator.canShare({ files: [file] })) {
         try { await navigator.share({ files: [file], text: "잔열 8.29 (금) 5:30PM · 001 라이브홀 🎫 #잔열" }); return; }
         catch (err) { if (err && err.name === "AbortError") return; }
       }
     }
-    if (!blob) { toast("이미지 생성 중…"); blob = await renderPassBlob(shareElementId); if (blob) PASS_BLOBS[shareElementId] = blob; }
+    if (!blob) { toast("이미지 생성 중…"); blob = await renderPassBlob(shareElementId, "image/jpeg"); if (blob) PASS_BLOBS[shareElementId] = blob; }
     if (!blob) throw new Error("이미지 변환 실패");
     const url = URL.createObjectURL(blob);
     if (!isIOS() && "download" in document.createElement("a")) {
@@ -401,7 +401,7 @@ function drawQR(elId, text) {
 
 const PASS_BLOBS = {};
 
-async function renderPassBlob(passElementId) {
+async function renderPassBlob(passElementId, mime) {
   const passEl = document.getElementById(passElementId);
   if (!passEl || !window.html2canvas) return null;
   const canvas = await window.html2canvas(passEl, {
@@ -410,13 +410,18 @@ async function renderPassBlob(passElementId) {
     useCORS: true,
     logging: false,
   });
-  return await new Promise((res) => canvas.toBlob(res, "image/png"));
+  // 인스타는 PNG 업로드가 막혀 있어 공유 카드는 JPEG로 내보냄
+  const type = mime || "image/png";
+  return await new Promise((res) => canvas.toBlob(res, type, type === "image/jpeg" ? 0.94 : undefined));
 }
+
+// 공유 카드(share-*)는 JPEG, 티켓 저장(pass-*)은 PNG
+const blobMime = (id) => (id.startsWith("share-") ? "image/jpeg" : "image/png");
 
 // 티켓 이미지를 미리 만들어 둠(공유 제스처 보존용)
 async function preparePass(passElementId) {
   try {
-    const blob = await renderPassBlob(passElementId);
+    const blob = await renderPassBlob(passElementId, blobMime(passElementId));
     if (blob) PASS_BLOBS[passElementId] = blob;
   } catch (_) { /* 저장 시 재생성 */ }
 }

--- a/ticket_2026_Janyeol/styles.css
+++ b/ticket_2026_Janyeol/styles.css
@@ -319,7 +319,7 @@ select { appearance: none;
 
 /* 인스타 공유용 카드(오프스크린)의 포스터 패널 — QR 자리 대체 */
 .share-poster { position: relative; border-radius: 8px; overflow: hidden; border: 1px solid #d8d8d8; background: #120806; }
-.share-poster img { width: 100%; height: 210px; object-fit: cover; object-position: center 22%; display: block; }
+.share-poster-img { width: 100%; height: 230px; background-size: cover; background-position: center 20%; background-repeat: no-repeat; }
 .share-poster-cap { position: absolute; left: 0; right: 0; bottom: 0; padding: 12px; background: linear-gradient(180deg, rgba(0,0,0,0), rgba(0,0,0,.82)); color: #fff; font-family: var(--f-mono); }
 .share-poster-cap .l1 { font-size: 14px; font-weight: 700; letter-spacing: 1px; }
 .share-poster-cap .l2 { font-size: 10px; opacity: .9; margin-top: 3px; }


### PR DESCRIPTION
## 변경 요약

인스타 공유용 티켓의 두 가지 문제를 수정했습니다.

### 1. 포스터가 눌려서(꾸겨져) 들어가던 문제
- 원인: `html2canvas`가 `<img>`의 `object-fit: cover`를 무시해서, 이미지가 박스에 맞춰 **늘어남(왜곡)**.
- 수정: 포스터를 `background-image`(div, `background-size: cover`)로 바꿔 **비율을 유지한 채 crop** 되도록 변경.

### 2. PNG → JPEG로 공유
- 인스타는 PNG 업로드가 막혀 있어, 공유 카드를 **JPEG(quality 0.94)**로 렌더·공유하도록 변경.
- 파일명 `.jpg`, 공유 시트 MIME `image/jpeg`.
- **티켓 저장(pass-\*)은 기존대로 PNG 유지**, 인스타 공유(share-\*)만 JPEG.

## 변경 파일
- `app.js` — 포스터 패널을 background-image div로 교체, `renderPassBlob`에 MIME 파라미터 추가, 공유는 JPEG
- `styles.css` — `.share-poster-img`(background cover) 규칙으로 교체

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZSE6K6bvp7cXWPpodjZRV)_