### PR TITLE
인스타 공유 티켓: QR 자리에 준비된(크롭된) 티켓 이미지 배치

### DIFF
--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -226,7 +226,7 @@ async function renderLoggedIn(user) {
         drawQR(`qr-${o.id}`, o.qr_token);
         // 티켓 이미지를 미리 생성 → iOS에서 버튼 탭 시 공유(사진 저장)가 제스처 안에서 즉시 동작
         setTimeout(() => preparePass(`pass-${o.id}`), 300);
-        prepareShareImage(o.id); // 인스타 공유용 이미지(그대로) 미리 준비
+        setTimeout(() => preparePass(`share-${o.id}`), 500);
       }
     });
     $("#addMore").onclick = () => {
@@ -300,7 +300,8 @@ function renderOrderCard(o) {
       </div>
 
       <div class="qr-note" style="margin-top:12px;">입장 시 위 티켓 QR을 확인자에게 보여주세요.<br/>확인되면 QR은 자동으로 만료됩니다. (화면 밝기 최대 권장)</div>
-      <div class="qr-code">코드 <code>${esc(o.qr_token)}</code> <button class="copy" data-copy="${esc(o.qr_token)}">복사</button></div>`;
+      <div class="qr-code">코드 <code>${esc(o.qr_token)}</code> <button class="copy" data-copy="${esc(o.qr_token)}">복사</button></div>
+      ${shareCardHTML(o)}`;
   } else if (o.status === "used") {
     body = `<div class="center" style="padding:18px 0 6px">
         <div class="qr-meta" style="font-size:26px">입장 완료</div>
@@ -321,35 +322,35 @@ function renderOrderCard(o) {
     </div>`;
 }
 
-// 인스타 공유용 이미지: 미리 준비해 둔 티켓 이미지(poster.ticket)를 그대로 사용.
-// 인스타가 PNG 업로드를 막아 JPEG로 변환해 캐시(제스처 안에서 즉시 공유되도록).
-const SHARE_SRC = (CFG.POSTER && (CFG.POSTER.ticket || CFG.POSTER.main)) || "";
-
-async function posterToJpegBlob(src) {
-  const img = new Image();
-  img.crossOrigin = "anonymous";
-  await new Promise((res, rej) => { img.onload = res; img.onerror = rej; img.src = src; });
-  const canvas = document.createElement("canvas");
-  canvas.width = img.naturalWidth || 1080;
-  canvas.height = img.naturalHeight || 1080;
-  const ctx = canvas.getContext("2d");
-  ctx.fillStyle = "#ffffff"; // JPEG는 투명 미지원 → 흰 배경
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-  ctx.drawImage(img, 0, 0);
-  return await new Promise((res) => canvas.toBlob(res, "image/jpeg", 0.95));
+// 인스타 공유용 카드(오프스크린): 티켓 모양 그대로, QR 자리에 "이미 크롭된" 티켓 이미지 배치(QR 없음).
+// object-fit로 잘라넣지 않고, 준비된 이미지를 자연 비율(width 100%)로 그대로 → html2canvas 왜곡 없음.
+function shareCardHTML(o) {
+  const poster = (CFG.POSTER && (CFG.POSTER.ticket || CFG.POSTER.main)) || "";
+  return `
+    <div style="position:fixed;left:-10000px;top:0;width:340px;pointer-events:none;" aria-hidden="true">
+      <div class="tech-ticket" id="share-${o.id}">
+        <div class="tech-ticket-head">
+          <div>
+            <div class="tech-ticket-title">${esc(EV.title || "JANYEOL")}</div>
+            <div class="tech-ticket-sub">${esc(EV.dateLabel || "8.29 FRI 5:30PM")} · ${esc(EV.venue || "001 LIVE HALL")}</div>
+          </div>
+          <div class="tech-ticket-badge">SECURED</div>
+        </div>
+        <div class="tech-ticket-grid">
+          <div class="tech-field"><span class="lbl">NAME</span><span class="val">${esc(o.buyer_name)}</span></div>
+          <div class="tech-field"><span class="lbl">QTY</span><span class="val">${o.quantity}인</span></div>
+          <div class="tech-field"><span class="lbl">DATE</span><span class="val">8.29 FRI</span></div>
+          <div class="tech-field"><span class="lbl">VENUE</span><span class="val">${esc(EV.venue || "001 HALL")}</span></div>
+        </div>
+        <div class="share-poster">
+          ${poster ? `<img class="share-poster-img" src="${esc(poster)}" alt="" crossorigin="anonymous" />` : ""}
+        </div>
+        <div class="tech-ticket-foot"><span>JANYEOL LIVE 2026</span><span>ADMIT ${o.quantity}</span></div>
+      </div>
+    </div>`;
 }
 
-async function prepareShareImage(orderId) {
-  if (!SHARE_SRC) return;
-  const key = `share-${orderId}`;
-  if (PASS_BLOBS[key]) return;
-  try {
-    const blob = await posterToJpegBlob(SHARE_SRC);
-    if (blob) PASS_BLOBS[key] = blob;
-  } catch (_) { /* 공유 시 재생성 */ }
-}
-
-// 인스타 공유(=OS 공유 시트). 준비해 둔 티켓 이미지를 그대로 내보냄(크롭/왜곡 없음).
+// 인스타 공유(=OS 공유 시트). QR 없는 포스터 카드라 공개해도 안전. 공유 카드는 JPEG.
 async function shareTicketImage(shareElementId, buyerName) {
   const fileName = `잔열티켓_${buyerName || "잔열"}.jpg`;
   try {
@@ -361,7 +362,7 @@ async function shareTicketImage(shareElementId, buyerName) {
         catch (err) { if (err && err.name === "AbortError") return; }
       }
     }
-    if (!blob) { toast("이미지 준비 중…"); blob = await posterToJpegBlob(SHARE_SRC); if (blob) PASS_BLOBS[shareElementId] = blob; }
+    if (!blob) { toast("이미지 준비 중…"); blob = await renderPassBlob(shareElementId, "image/jpeg"); if (blob) PASS_BLOBS[shareElementId] = blob; }
     if (!blob) throw new Error("이미지 변환 실패");
     const url = URL.createObjectURL(blob);
     if (!isIOS() && "download" in document.createElement("a")) {
@@ -397,7 +398,7 @@ function drawQR(elId, text) {
 
 const PASS_BLOBS = {};
 
-async function renderPassBlob(passElementId) {
+async function renderPassBlob(passElementId, mime) {
   const passEl = document.getElementById(passElementId);
   if (!passEl || !window.html2canvas) return null;
   const canvas = await window.html2canvas(passEl, {
@@ -406,13 +407,18 @@ async function renderPassBlob(passElementId) {
     useCORS: true,
     logging: false,
   });
-  return await new Promise((res) => canvas.toBlob(res, "image/png"));
+  // 인스타는 PNG 업로드가 막혀 있어 공유 카드는 JPEG로 내보냄
+  const type = mime || "image/png";
+  return await new Promise((res) => canvas.toBlob(res, type, type === "image/jpeg" ? 0.95 : undefined));
 }
+
+// 공유 카드(share-*)는 JPEG, 티켓 저장(pass-*)은 PNG
+const blobMime = (id) => (id.startsWith("share-") ? "image/jpeg" : "image/png");
 
 // 티켓 이미지를 미리 만들어 둠(공유 제스처 보존용)
 async function preparePass(passElementId) {
   try {
-    const blob = await renderPassBlob(passElementId);
+    const blob = await renderPassBlob(passElementId, blobMime(passElementId));
     if (blob) PASS_BLOBS[passElementId] = blob;
   } catch (_) { /* 저장 시 재생성 */ }
 }

--- a/ticket_2026_Janyeol/styles.css
+++ b/ticket_2026_Janyeol/styles.css
@@ -317,6 +317,10 @@ select { appearance: none;
 }
 .share-ticket-btn:active { transform: scale(.98); filter: brightness(.95); }
 
+/* 인스타 공유용 카드(오프스크린)의 포스터 패널 — QR 자리 대체. 이미 크롭된 이미지라 자연 비율로 그대로 표시 */
+.share-poster { position: relative; border-radius: 8px; overflow: hidden; border: 1px solid #d8d8d8; background: #120806; }
+.share-poster-img { display: block; width: 100%; height: auto; }
+
 .qr-wrap { text-align: center; }
 .qr-box { display: inline-block; background: #fff; padding: 16px; border-radius: 12px; margin: 12px auto 8px; box-shadow: 0 0 0 1px rgba(255,120,40,.2), 0 18px 44px rgba(226,54,13,.22); }
 .qr-box img, .qr-box canvas { display: block; }


### PR DESCRIPTION
## 변경 요약

인스타 공유 티켓을 의도한 형태로 정정했습니다. 티켓 카드 디자인은 그대로 두고, **QR이 있던 자리에 이미 크롭돼 있는 전용 이미지(`poster-main-ticket.png`)를 그대로** 넣습니다.

### 무엇이 문제였나
- `poster-main.jpg`를 티켓 박스 안에 `object-fit: cover`로 잘라 넣어서, 모바일/기기에 따라 이미지가 눌리거나(왜곡) 이상하게 잘렸습니다.
- 직전(#41)에는 "이미지 자체를 통째로 공유"하는 방식이 머지됐는데, 원래 원하신 건 **카드 안에 이미지가 들어간 티켓** 형태였습니다.

### 수정
- 티켓 카드(헤더 · NAME/QTY/DATE/VENUE · 푸터)는 그대로 유지.
- QR 자리 패널에 `poster-main-ticket.png`를 **자연 비율(`width:100%`, `object-fit` 미사용)**로 배치 → 왜곡/크롭 없음.
- 이미지에 날짜·장소가 이미 박혀 있어, 겹치던 캡션 오버레이는 제거.
- 공유 카드는 **JPEG(quality 0.95)**로 렌더·공유(인스타 PNG 업로드 제한 대응), iOS 공유 제스처 보존을 위해 발급 시 미리 렌더.

## 변경 파일
- `app.js` — `shareCardHTML`에서 QR 자리 이미지를 `<img>`(자연 비율)로 배치, 캡션 제거, 공유는 JPEG
- `styles.css` — `.share-poster-img`를 자연 비율(`height:auto`)로

## 미리보기
아래처럼 이미지가 눌리지 않고 원본 비율 그대로 카드 안에 들어갑니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZSE6K6bvp7cXWPpodjZRV)_