### PR TITLE
날짜 요일 정정: 8.29는 토요일 (금 → 토 / FRI → SAT)

### DIFF
--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -257,7 +257,7 @@ function renderOrderCard(o) {
         <div class="tech-ticket-head">
           <div>
             <div class="tech-ticket-title">${esc(EV.title || "JANYEOL")}</div>
-            <div class="tech-ticket-sub">${esc(EV.dateLabel || "8.29 FRI 5:30PM")} · ${esc(EV.venue || "001 LIVE HALL")}</div>
+            <div class="tech-ticket-sub">${esc(EV.dateLabel || "8.29 SAT 5:30PM")} · ${esc(EV.venue || "001 LIVE HALL")}</div>
           </div>
           <div class="tech-ticket-badge">CONFIRMED</div>
         </div>
@@ -332,14 +332,14 @@ function shareCardHTML(o) {
         <div class="tech-ticket-head">
           <div>
             <div class="tech-ticket-title">${esc(EV.title || "JANYEOL")}</div>
-            <div class="tech-ticket-sub">${esc(EV.dateLabel || "8.29 FRI 5:30PM")} · ${esc(EV.venue || "001 LIVE HALL")}</div>
+            <div class="tech-ticket-sub">${esc(EV.dateLabel || "8.29 SAT 5:30PM")} · ${esc(EV.venue || "001 LIVE HALL")}</div>
           </div>
           <div class="tech-ticket-badge">SECURED</div>
         </div>
         <div class="tech-ticket-grid">
           <div class="tech-field"><span class="lbl">NAME</span><span class="val">${esc(o.buyer_name)}</span></div>
           <div class="tech-field"><span class="lbl">QTY</span><span class="val">${o.quantity}인</span></div>
-          <div class="tech-field"><span class="lbl">DATE</span><span class="val">8.29 FRI</span></div>
+          <div class="tech-field"><span class="lbl">DATE</span><span class="val">8.29 SAT</span></div>
           <div class="tech-field"><span class="lbl">VENUE</span><span class="val">${esc(EV.venue || "001 HALL")}</span></div>
         </div>
         <div class="share-poster">
@@ -358,7 +358,7 @@ async function shareTicketImage(shareElementId, buyerName) {
     if (blob && navigator.canShare) {
       const file = new File([blob], fileName, { type: "image/jpeg" });
       if (navigator.canShare({ files: [file] })) {
-        try { await navigator.share({ files: [file], text: "잔열 8.29 (금) 5:30PM · 001 라이브홀 🎫 #잔열" }); return; }
+        try { await navigator.share({ files: [file], text: "잔열 8.29 (토) 5:30PM · 001 라이브홀 🎫 #잔열" }); return; }
         catch (err) { if (err && err.name === "AbortError") return; }
       }
     }

--- a/ticket_2026_Janyeol/config.js
+++ b/ticket_2026_Janyeol/config.js
@@ -27,7 +27,7 @@ window.JANYEOL_CONFIG = {
   EVENT: {
     title: "잔열",
     subtitle: "殘熱",
-    dateLabel: "8.29 (금) 5:30PM",
+    dateLabel: "8.29 (토) 5:30PM",
     venue: "001 라이브홀",
     address: "서울 마포구 월드컵로 140 지하1층",
     price: 7000,

--- a/ticket_2026_Janyeol/index.html
+++ b/ticket_2026_Janyeol/index.html
@@ -6,9 +6,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
   <meta name="theme-color" content="#0a0605" />
   <title>잔열 殘熱 · LIVE</title>
-  <meta name="description" content="잔열 공연 티켓 — 8.29 FRI 5:30PM · 001 라이브홀" />
+  <meta name="description" content="잔열 공연 티켓 — 8.29 SAT 5:30PM · 001 라이브홀" />
   <meta property="og:title" content="잔열 殘熱 · LIVE" />
-  <meta property="og:description" content="8.29 (금) 5:30PM · 001 라이브홀 · 7,000원" />
+  <meta property="og:description" content="8.29 (토) 5:30PM · 001 라이브홀 · 7,000원" />
   <meta property="og:type" content="website" />
   <link rel="preconnect" href="https://cdn.jsdelivr.net" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/ticket_2026_Janyeol/mail-apps-script.gs
+++ b/ticket_2026_Janyeol/mail-apps-script.gs
@@ -45,7 +45,7 @@ function doPost(e) {
             '<div style="font-family:monospace;font-size:11px;color:#555;margin-top:8px;word-break:break-all;">CODE: ' + _esc(code) + '</div>' +
           '</div>' +
           '<table style="width:100%;font-size:14px;border-collapse:collapse;">' +
-            _row('공연', '잔열 · 8.29 (금) 5:30PM') +
+            _row('공연', '잔열 · 8.29 (토) 5:30PM') +
             _row('장소', '001 라이브홀 (서울 마포구 월드컵로 140 지하1층)') +
             _row('예매자', _esc(name)) +
             _row('수량 / 금액', qty + ' · ' + won) +


### PR DESCRIPTION
## 변경 요약

**2026-08-29는 토요일**인데, 사이트 여러 곳에 금요일(금 / FRI)로 잘못 표기돼 있어 전부 확인하고 수정했습니다.

## 수정한 곳
| 파일 | 위치 | 변경 |
|---|---|---|
| `config.js` | `EVENT.dateLabel` | `8.29 (금)` → `8.29 (토)` |
| `app.js` | 티켓/공유 카드 부제 fallback | `8.29 FRI 5:30PM` → `8.29 SAT 5:30PM` (2곳) |
| `app.js` | 공유 카드 DATE 필드 | `8.29 FRI` → `8.29 SAT` |
| `app.js` | 공유 텍스트 | `8.29 (금)` → `8.29 (토)` |
| `index.html` | `description` | `8.29 FRI` → `8.29 SAT` |
| `index.html` | `og:description` | `8.29 (금)` → `8.29 (토)` |
| `mail-apps-script.gs` | 이메일 공연 정보 | `8.29 (금)` → `8.29 (토)` |

> 메인 배너(`index.html`의 `#bDate`)는 이미 `8.29 (토)`로 되어 있어 그대로 두었습니다.
> 저장소 전체를 `FRI`/`(금`/`금)`/`금요일`로 재검색해 남은 표기가 없음을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZSE6K6bvp7cXWPpodjZRV)_