### PR TITLE
예매 2단계 위저드 + 공연자 티켓 저장/공유

### DIFF
--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -402,7 +402,7 @@ function renderOrderCard(o) {
         <div class="qr-meta" style="font-size:22px">여기로 입금해 주세요</div>
         <div class="qr-note">예매가 <b>접수</b>됐어요. 입금이 확인되면 이 화면에 <b>입장 QR</b>이 자동으로 떠요.</div>
       </div>
-      ${payStepHTML(o.amount)}
+      ${paymentInstructionsHTML(o.method, o.amount)}
       <div class="notice">입금 확인은 <b>수동</b>이라 <b>최대 하루</b> 정도 걸릴 수 있어요. 확인되면 <b>예매하신 이메일로 티켓과 링크</b>를 보내드리고, 이 화면에도 <b>입장 QR</b>이 자동으로 떠요. <b>📩 이메일을 확인해 주세요.</b><br/><span style="color:var(--dim)">메일을 못 받아도 이 사이트에 <b style="color:var(--muted)">로그인하면 언제든 확인</b>할 수 있어요.</span></div>`;
   }
   return `<div class="card">
@@ -712,26 +712,44 @@ function accountBoxHTML(amount) {
     </div>`;
 }
 
-// STEP 2 입금 안내(계좌 + 송금 링크 + 토스). 뱅킹앱 QR 이미지는 넣지 않음(입장 QR과 혼동 방지).
-function payStepHTML(amount) {
+function paymentInstructionsHTML(method, amount) {
   const B = CFG.BANK || {};
   const T = CFG.TRANSFER || {};
   const acct = (B.account || "").replace(/[^0-9]/g, "");
   const tossBankCode = B.tossBankCode || "TOSS";
   const tossDeepLink = `supertoss://send?bank=${encodeURIComponent(tossBankCode)}&accountNo=${encodeURIComponent(acct)}&amount=${amount}`;
-  const linkBtn = T.link
-    ? `<a class="linkout-btn" href="${esc(T.link)}" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>뱅킹앱으로 바로 송금하기</a>`
-    : "";
+
+  const acctRows = `
+      <div class="row"><span class="k">은행</span><span class="v">${esc(B.bank || "")}</span></div>
+      <div class="row"><span class="k">계좌번호</span><span class="v">${esc(B.account || "")}
+        <button class="copy" data-copy="${esc(acct)}">복사</button></span></div>
+      ${B.holder ? `<div class="row"><span class="k">예금주</span><span class="v">${esc(B.holder)}</span></div>` : ""}
+      <div class="row"><span class="k">보낼 금액</span><span class="v" style="color:var(--gold)">${won(amount)}</span></div>`;
+  const depositHint = `<p class="hint">입금자명을 정확히 남겨주세요. 대조하여 확인 후 QR이 발급됩니다.</p>`;
+
+  if (method === "qr") {
+    // 뱅킹앱 QR: 카메라 스캔 + 'QR 링크로 이동하기' 버튼 (토스 버튼 없음)
+    return `<div class="pay-box">
+      ${T.qrImage ? `<div class="center"><img src="${esc(T.qrImage)}" alt="송금 QR" style="max-width:230px;border-radius:12px" onerror="this.parentNode.style.display='none'"/></div>
+      <p class="hint center"><b>휴대폰 카메라로 이 송금용 QR을 스캔</b>해 송금하세요.<br/><span style="color:var(--dim)">(공연 입장용 <b style="color:var(--muted)">티켓 QR</b>은 이 QR과 달라요. 입금 확인 후 로그인 화면에 따로 떠요.)</span></p>` : ""}
+      ${T.link ? `<p class="hint center" style="margin-top:2px">혹은 아래 버튼을 눌러 <b>뱅킹앱에서 바로 송금</b>할 수 있어요.</p>
+      <a class="linkout-btn" href="${esc(T.link)}" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>QR 링크로 이동하기</a>` : ""}
+      ${acctRows}
+    </div>
+    ${depositHint}`;
+  }
+
+  // 계좌번호: 계좌 복사가 기본, 아래에 '또는 간편하게' 구분 + 토스 버튼(분리)
   const tossBtn = acct
     ? `<button type="button" class="toss-btn" onclick="window.location.href='${tossDeepLink}'">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14.5v-9l6 4.5-6 4.5z"/></svg>
         토스앱으로 간편하게 입금하기
       </button>`
     : "";
-  return `${accountBoxHTML(amount)}
-    ${linkBtn}
+  return `<div class="pay-box">${acctRows}
+    </div>
     ${tossBtn ? `<div class="pay-or">또는 간편하게</div>${tossBtn}` : ""}
-    <p class="hint">입금자명을 정확히 남겨주세요. 대조하여 확인 후 입장 QR이 발급됩니다.</p>`;
+    ${depositHint}`;
 }
 
 // ---------------- 구매 폼 ----------------
@@ -747,11 +765,17 @@ function mountBuyForm() {
       <label class="fld">예매자 실명*</label>
       <input id="fName" placeholder="이름" value="${esc(prefill)}" autocomplete="name" />
 
-      <label class="fld">입금자명 *</label>
-      <input id="fDep" placeholder="입금하실 분 이름" value="${esc(prefill)}" />
-
       <label class="fld">연락처 *</label>
       <input id="fPhone" placeholder="010-0000-0000" inputmode="tel" autocomplete="tel" />
+
+      <label class="fld">결제 방법 *</label>
+      <div class="seg" id="segMethod">
+        <button type="button" data-m="bank" class="on">계좌번호</button>
+        <button type="button" data-m="qr">뱅킹앱 QR</button>
+      </div>
+
+      <label class="fld">입금자명 *</label>
+      <input id="fDep" placeholder="입금자 이름" value="${esc(prefill)}" />
 
       <label class="fld">수량 *</label>
       <div class="qty">
@@ -763,11 +787,19 @@ function mountBuyForm() {
 
       <div class="total"><span class="lbl">총 금액</span><span class="amt" id="tAmt">${won(PRICE)}</span></div>
       <button class="btn" id="submitBtn">입금 단계로 넘어가기 · <span id="btnAmt">${won(PRICE)}</span></button>
-      <div class="notice">먼저 예매자 정보를 <b>접수</b>하면, 바로 다음 화면에서 <b>입금 계좌·송금 링크</b>를 안내해 드려요. <b>지금 접수해두면 기록이 남아</b> 혹시 입금 확인이 늦어도 안전하게 처리돼요.<br/><span style="color:var(--dim)">아직 송금하지 않아도 괜찮아요 — 접수 후 안내대로 입금하시면 됩니다.</span></div>
+      <div class="notice">먼저 예매자 정보를 <b>접수</b>하면, 다음 화면에서 <b>입금 방법(계좌·송금 QR)</b>을 안내해 드려요. <b>지금 접수해두면 기록이 남아</b> 혹시 입금 확인이 늦어도 안전하게 처리돼요.<br/><span style="color:var(--dim)">아직 송금하지 않아도 괜찮아요 — 접수 후 안내대로 입금하시면 됩니다.</span></div>
       <div class="notice">현장 예매도 가능합니다.</div>
       <div class="err" id="formErr"></div>
     </div>`;
 
+  const seg = $("#segMethod");
+  seg.querySelectorAll("button").forEach((b) => {
+    b.onclick = () => {
+      seg.querySelectorAll("button").forEach((x) => x.classList.remove("on"));
+      b.classList.add("on");
+      FORM.method = b.dataset.m;
+    };
+  });
   $("#qMinus").onclick = () => setQty(FORM.qty - 1);
   $("#qPlus").onclick = () => setQty(FORM.qty + 1);
   $("#submitBtn").onclick = submitOrder;

--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -256,7 +256,7 @@ async function renderLoggedIn(user) {
   CURRENT_USER = user;
   const { data: orders, error } = await sb
     .from("tk_orders")
-    .select("id,buyer_name,quantity,amount,method,status,qr_token,used_at,created_at")
+    .select("id,buyer_name,quantity,amount,method,status,qr_token,used_at,created_at,paid_at")
     .eq("user_id", user.id)
     .in("status", ["pending", "confirmed", "used"])
     .order("created_at", { ascending: false });
@@ -397,12 +397,16 @@ function renderOrderCard(o) {
         <div class="qr-note">ENTERED · ${o.used_at ? new Date(o.used_at).toLocaleString("ko-KR") : ""}</div>
       </div>`;
   } else {
-    body = `<div class="center" style="padding:6px 0 2px">
-        <div class="kicker" style="color:var(--gold)">STEP 2 · 입금</div>
-        <div class="qr-meta" style="font-size:22px">여기로 입금해 주세요</div>
-        <div class="qr-note">예매가 <b>접수</b>됐어요. 입금이 확인되면 이 화면에 <b>입장 QR</b>이 자동으로 떠요.</div>
+    body = `<div class="center" style="padding:10px 0 4px">
+        <div class="qr-meta" style="font-size:22px">${o.paid_at ? "입금 완료 신고 접수" : "입장 QR 대기중"}</div>
+        <div class="qr-note">${o.paid_at ? "입금 확인 후 이 화면에 <b>입장 QR</b>이 자동으로 떠요." : "입금이 확인되면 QR이 여기에 자동으로 떠요."}</div>
       </div>
-      ${paymentInstructionsHTML(o.method, o.amount)}
+      <div class="pay-box" style="margin-top:12px">
+        <div class="row"><span class="k">예매자</span><span class="v">${esc(o.buyer_name)}</span></div>
+        <div class="row"><span class="k">수량</span><span class="v">${o.quantity}인</span></div>
+        <div class="row"><span class="k">금액</span><span class="v" style="color:var(--gold)">${won(o.amount)}</span></div>
+      </div>
+      ${o.paid_at ? "" : accountBoxHTML(o.amount)}
       <div class="notice">입금 확인은 <b>수동</b>이라 <b>최대 하루</b> 정도 걸릴 수 있어요. 확인되면 <b>예매하신 이메일로 티켓과 링크</b>를 보내드리고, 이 화면에도 <b>입장 QR</b>이 자동으로 떠요. <b>📩 이메일을 확인해 주세요.</b><br/><span style="color:var(--dim)">메일을 못 받아도 이 사이트에 <b style="color:var(--muted)">로그인하면 언제든 확인</b>할 수 있어요.</span></div>`;
   }
   return `<div class="card">
@@ -752,30 +756,85 @@ function paymentInstructionsHTML(method, amount) {
     ${depositHint}`;
 }
 
-// ---------------- 구매 폼 ----------------
+// ---------------- 구매 폼 (2단계) ----------------
 let FORM = { method: "bank", qty: 1 };
+let DRAFT_ID = null;        // STEP 1에서 만든 접수 레코드 id
+let WIZARD_ACTIVE = false;  // STEP 2 진행 중엔 실시간 새로고침으로 화면이 바뀌지 않게
 
+// STEP 1 · 이름 + 연락처만 입력 → '다음' 누르면 기록 먼저 생성
 function mountBuyForm() {
   FORM = { method: "bank", qty: 1 };
+  DRAFT_ID = null;
   const mount = $("#buyMount");
   const prefill = CURRENT_USER?.user_metadata?.full_name || "";
   mount.innerHTML = `
     <div class="card">
-      <div class="kicker" style="color:var(--gold);margin-bottom:6px">STEP 1 · 예매 접수</div>
+      <div class="kicker" style="color:var(--gold);margin-bottom:6px">STEP 1 · 예매자 정보</div>
       <label class="fld">예매자 실명*</label>
       <input id="fName" placeholder="이름" value="${esc(prefill)}" autocomplete="name" />
 
       <label class="fld">연락처 *</label>
       <input id="fPhone" placeholder="010-0000-0000" inputmode="tel" autocomplete="tel" />
 
+      <button class="btn" id="nextBtn" style="margin-top:18px">다음 · 입금 방법 선택 →</button>
+      <div class="notice">이름과 연락처만 먼저 <b>접수</b>하면 <b>기록이 남아요.</b> 다음 화면에서 <b>입금 방법과 수량</b>을 정하고 <b>‘입금 완료했어요’</b>로 마무리하면 됩니다.</div>
+      <div class="notice">현장 예매도 가능합니다.</div>
+      <div class="err" id="formErr"></div>
+    </div>`;
+  $("#nextBtn").onclick = submitStep1;
+}
+
+async function submitStep1() {
+  const name = $("#fName").value.trim();
+  const phone = $("#fPhone").value.trim();
+  const err = $("#formErr");
+  err.textContent = "";
+  if (!name) return (err.textContent = "이름을 입력해주세요.");
+  if (phone.replace(/[^0-9]/g, "").length < 9) return (err.textContent = "연락처를 정확히 입력해주세요.");
+
+  const btn = $("#nextBtn");
+  btn.disabled = true;
+  btn.textContent = "접수 중…";
+  WIZARD_ACTIVE = true; // 접수 insert로 인한 실시간 새로고침 억제(STEP 2 유지)
+
+  const { data, error } = await sb
+    .from("tk_orders")
+    .insert({
+      email: CURRENT_USER.email,
+      buyer_name: name,
+      phone: phone,
+      depositor_name: name,
+      quantity: 1,
+      method: "bank",
+      amount: PRICE,
+      status: "pending",
+    })
+    .select("id")
+    .single();
+
+  if (error || !data) {
+    WIZARD_ACTIVE = false;
+    btn.disabled = false;
+    btn.textContent = "다음 · 입금 방법 선택 →";
+    err.textContent = "접수 실패: " + (error?.message || "");
+    return;
+  }
+  DRAFT_ID = data.id;
+  FORM = { method: "bank", qty: 1 };
+  renderBuyStep2(name);
+}
+
+// STEP 2 · 결제 방법 + 수량 선택 → '입금 완료했어요'
+function renderBuyStep2(name) {
+  const mount = $("#buyMount");
+  mount.innerHTML = `
+    <div class="card">
+      <div class="kicker" style="color:var(--gold);margin-bottom:6px">STEP 2 · 입금</div>
       <label class="fld">결제 방법 *</label>
       <div class="seg" id="segMethod">
         <button type="button" data-m="bank" class="on">계좌번호</button>
         <button type="button" data-m="qr">뱅킹앱 QR</button>
       </div>
-
-      <label class="fld">입금자명 *</label>
-      <input id="fDep" placeholder="입금자 이름" value="${esc(prefill)}" />
 
       <label class="fld">수량 *</label>
       <div class="qty">
@@ -785,10 +844,15 @@ function mountBuyForm() {
         <span class="hint" style="margin:0 0 0 6px">최대 ${MAXQ}인</span>
       </div>
 
+      <label class="fld">입금자명 *</label>
+      <input id="fDep" placeholder="입금하실 분 이름" value="${esc(name || "")}" />
+
+      <label class="fld">여기로 송금해 주세요</label>
+      <div id="payArea"></div>
+
       <div class="total"><span class="lbl">총 금액</span><span class="amt" id="tAmt">${won(PRICE)}</span></div>
-      <button class="btn" id="submitBtn">입금 단계로 넘어가기 · <span id="btnAmt">${won(PRICE)}</span></button>
-      <div class="notice">먼저 예매자 정보를 <b>접수</b>하면, 다음 화면에서 <b>입금 방법(계좌·송금 QR)</b>을 안내해 드려요. <b>지금 접수해두면 기록이 남아</b> 혹시 입금 확인이 늦어도 안전하게 처리돼요.<br/><span style="color:var(--dim)">아직 송금하지 않아도 괜찮아요 — 접수 후 안내대로 입금하시면 됩니다.</span></div>
-      <div class="notice">현장 예매도 가능합니다.</div>
+      <button class="btn" id="submitBtn">입금 완료했어요 · <span id="btnAmt">${won(PRICE)}</span></button>
+      <div class="notice">위 계좌(또는 QR)로 송금한 뒤 <b>‘입금 완료했어요’</b>를 눌러주세요. 입금 확인은 <b>수동</b>이라 <b>최대 하루</b> 정도 걸릴 수 있어요. 확인되면 <b>예매하신 이메일로 티켓과 링크</b>를 보내드리고, 로그인 화면에도 공연 입장용 <b>티켓 QR</b>이 떠요. <b>📩 이메일을 확인해 주세요.</b><br/><span style="color:var(--dim)">이 티켓 QR은 <b style="color:var(--muted)">송금할 때 쓴 QR과는 다른</b>, 공연 당일 입장용 QR이에요.</span></div>
       <div class="err" id="formErr"></div>
     </div>`;
 
@@ -798,11 +862,47 @@ function mountBuyForm() {
       seg.querySelectorAll("button").forEach((x) => x.classList.remove("on"));
       b.classList.add("on");
       FORM.method = b.dataset.m;
+      updatePayArea();
     };
   });
   $("#qMinus").onclick = () => setQty(FORM.qty - 1);
   $("#qPlus").onclick = () => setQty(FORM.qty + 1);
-  $("#submitBtn").onclick = submitOrder;
+  $("#submitBtn").onclick = submitStep2;
+  updatePayArea();
+}
+
+async function submitStep2() {
+  const dep = $("#fDep").value.trim();
+  const err = $("#formErr");
+  err.textContent = "";
+  if (!dep) return (err.textContent = "입금자명을 입력해주세요.");
+  if (!DRAFT_ID) { mountBuyForm(); return; }
+
+  const btn = $("#submitBtn");
+  btn.disabled = true;
+  btn.textContent = "처리 중…";
+
+  const { error } = await sb
+    .from("tk_orders")
+    .update({
+      depositor_name: dep,
+      quantity: FORM.qty,
+      method: FORM.method,
+      amount: PRICE * FORM.qty,
+      paid_at: new Date().toISOString(),
+    })
+    .eq("id", DRAFT_ID);
+
+  if (error) {
+    btn.disabled = false;
+    btn.textContent = "입금 완료했어요";
+    err.textContent = "처리 실패: " + error.message;
+    return;
+  }
+  WIZARD_ACTIVE = false;
+  DRAFT_ID = null;
+  toast("입금 완료 신고를 받았어요! 확인을 기다려주세요.");
+  await refresh();
 }
 
 function setQty(q) {
@@ -811,6 +911,14 @@ function setQty(q) {
   const amt = won(PRICE * FORM.qty);
   $("#tAmt").textContent = amt;
   $("#btnAmt").textContent = amt;
+  updatePayArea();
+}
+
+function updatePayArea() {
+  const el = $("#payArea");
+  if (!el) return;
+  el.innerHTML = paymentInstructionsHTML(FORM.method, PRICE * FORM.qty);
+  wireCopy(el);
 }
 
 function wireCopy(root) {
@@ -876,45 +984,11 @@ async function addToAppleWallet(orderId, button) {
   }
 }
 
-async function submitOrder() {
-  const name = $("#fName").value.trim();
-  const dep = $("#fDep").value.trim();
-  const phone = $("#fPhone").value.trim();
-  const err = $("#formErr");
-  err.textContent = "";
-  if (!name) return (err.textContent = "받는 분 이름을 입력해주세요.");
-  if (phone.replace(/[^0-9]/g, "").length < 9) return (err.textContent = "연락처를 정확히 입력해주세요.");
-  if (!dep) return (err.textContent = "입금자명을 입력해주세요.");
-
-  const btn = $("#submitBtn");
-  btn.disabled = true;
-  btn.textContent = "접수 중…";
-
-  const { error } = await sb.from("tk_orders").insert({
-    email: CURRENT_USER.email,
-    buyer_name: name,
-    phone: phone,
-    depositor_name: dep,
-    quantity: FORM.qty,
-    method: FORM.method,
-    amount: PRICE * FORM.qty,
-    status: "pending",
-  });
-
-  if (error) {
-    btn.disabled = false;
-    btn.textContent = "입금 단계로 넘어가기";
-    err.textContent = "접수 실패: " + error.message;
-    return;
-  }
-  toast("접수 완료! 아래 안내대로 입금해 주세요.");
-  await refresh();
-}
-
 // ---------------- 실시간 ----------------
 let channel = null;
 let refreshTimer = null;
 function scheduleRefresh() {
+  if (WIZARD_ACTIVE) return; // STEP 2 입력 중엔 화면 유지
   clearTimeout(refreshTimer);
   refreshTimer = setTimeout(() => refresh(CURRENT_USER), 150);
 }

--- a/ticket_2026_Janyeol/app.js
+++ b/ticket_2026_Janyeol/app.js
@@ -398,11 +398,11 @@ function renderOrderCard(o) {
       </div>`;
   } else {
     body = `<div class="center" style="padding:6px 0 2px">
-        <div class="qr-meta" style="font-size:22px">입장 QR 대기중</div>
-        <div class="qr-note">입금이 확인되면 QR이 여기에 자동으로 떠요.</div>
+        <div class="kicker" style="color:var(--gold)">STEP 2 · 입금</div>
+        <div class="qr-meta" style="font-size:22px">여기로 입금해 주세요</div>
+        <div class="qr-note">예매가 <b>접수</b>됐어요. 입금이 확인되면 이 화면에 <b>입장 QR</b>이 자동으로 떠요.</div>
       </div>
-      ${depositReminder(o.amount)}
-      ${accountBoxHTML(o.amount)}
+      ${payStepHTML(o.amount)}
       <div class="notice">입금 확인은 <b>수동</b>이라 <b>최대 하루</b> 정도 걸릴 수 있어요. 확인되면 <b>예매하신 이메일로 티켓과 링크</b>를 보내드리고, 이 화면에도 <b>입장 QR</b>이 자동으로 떠요. <b>📩 이메일을 확인해 주세요.</b><br/><span style="color:var(--dim)">메일을 못 받아도 이 사이트에 <b style="color:var(--muted)">로그인하면 언제든 확인</b>할 수 있어요.</span></div>`;
   }
   return `<div class="card">
@@ -699,18 +699,6 @@ async function saveTicketImage(passElementId, buyerName) {
 // ---------------- 결제 안내 ----------------
 const methodLabel = (m) => (m === "qr" ? "뱅킹앱 송금" : m === "cash" ? "현금" : "계좌이체");
 
-// 입금 전이면 어디로 얼마 보내야 하는지 명확히 (QR 발급 전까지 계속 노출)
-function depositReminder(amount) {
-  const B = CFG.BANK || {};
-  const acct = B.bank && B.account
-    ? `${esc(B.bank)} ${esc(B.account)}${B.holder ? ` (${esc(B.holder)})` : ""}`
-    : "";
-  return `<div class="notice" style="border-left-color:var(--gold);background:rgba(230,165,60,.12)">
-      아직 입금 전이라면 <b>${acct}</b> 로 <b>${won(amount)}</b> 입금해 주세요.<br/>
-      입금이 확인되면 이 화면에 <b>입장 QR</b>이 자동으로 떠요.
-    </div>`;
-}
-
 // 계좌 정보만 (QR/버튼 없이) — 대기 카드에서 사용
 function accountBoxHTML(amount) {
   const B = CFG.BANK || {};
@@ -724,44 +712,26 @@ function accountBoxHTML(amount) {
     </div>`;
 }
 
-function paymentInstructionsHTML(method, amount) {
+// STEP 2 입금 안내(계좌 + 송금 링크 + 토스). 뱅킹앱 QR 이미지는 넣지 않음(입장 QR과 혼동 방지).
+function payStepHTML(amount) {
   const B = CFG.BANK || {};
   const T = CFG.TRANSFER || {};
   const acct = (B.account || "").replace(/[^0-9]/g, "");
   const tossBankCode = B.tossBankCode || "TOSS";
   const tossDeepLink = `supertoss://send?bank=${encodeURIComponent(tossBankCode)}&accountNo=${encodeURIComponent(acct)}&amount=${amount}`;
-
-  const acctRows = `
-      <div class="row"><span class="k">은행</span><span class="v">${esc(B.bank || "")}</span></div>
-      <div class="row"><span class="k">계좌번호</span><span class="v">${esc(B.account || "")}
-        <button class="copy" data-copy="${esc(acct)}">복사</button></span></div>
-      ${B.holder ? `<div class="row"><span class="k">예금주</span><span class="v">${esc(B.holder)}</span></div>` : ""}
-      <div class="row"><span class="k">보낼 금액</span><span class="v" style="color:var(--gold)">${won(amount)}</span></div>`;
-  const depositHint = `<p class="hint">입금자명을 정확히 남겨주세요. 대조하여 확인 후 QR이 발급됩니다.</p>`;
-
-  if (method === "qr") {
-    // 뱅킹앱 QR: 카메라 스캔 + 'QR 링크로 이동하기' 버튼 (토스 버튼 없음)
-    return `<div class="pay-box">
-      ${T.qrImage ? `<div class="center"><img src="${esc(T.qrImage)}" alt="송금 QR" style="max-width:230px;border-radius:12px" onerror="this.parentNode.style.display='none'"/></div>
-      <p class="hint center"><b>휴대폰 카메라로 이 송금용 QR을 스캔</b>해 송금하세요.<br/><span style="color:var(--dim)">(공연 입장용 <b style="color:var(--muted)">티켓 QR</b>은 이 QR과 달라요. 입금 확인 후 로그인 화면에 따로 떠요.)</span></p>` : ""}
-      ${T.link ? `<p class="hint center" style="margin-top:2px">혹은 아래 버튼을 눌러 <b>뱅킹앱에서 바로 송금</b>할 수 있어요.</p>
-      <a class="linkout-btn" href="${esc(T.link)}" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>QR 링크로 이동하기</a>` : ""}
-      ${acctRows}
-    </div>
-    ${depositHint}`;
-  }
-
-  // 계좌번호: 계좌 복사가 기본, 아래에 '또는 간편하게' 구분 + 토스 버튼(분리)
+  const linkBtn = T.link
+    ? `<a class="linkout-btn" href="${esc(T.link)}" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>뱅킹앱으로 바로 송금하기</a>`
+    : "";
   const tossBtn = acct
     ? `<button type="button" class="toss-btn" onclick="window.location.href='${tossDeepLink}'">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14.5v-9l6 4.5-6 4.5z"/></svg>
         토스앱으로 간편하게 입금하기
       </button>`
     : "";
-  return `<div class="pay-box">${acctRows}
-    </div>
+  return `${accountBoxHTML(amount)}
+    ${linkBtn}
     ${tossBtn ? `<div class="pay-or">또는 간편하게</div>${tossBtn}` : ""}
-    ${depositHint}`;
+    <p class="hint">입금자명을 정확히 남겨주세요. 대조하여 확인 후 입장 QR이 발급됩니다.</p>`;
 }
 
 // ---------------- 구매 폼 ----------------
@@ -773,19 +743,15 @@ function mountBuyForm() {
   const prefill = CURRENT_USER?.user_metadata?.full_name || "";
   mount.innerHTML = `
     <div class="card">
+      <div class="kicker" style="color:var(--gold);margin-bottom:6px">STEP 1 · 예매 접수</div>
       <label class="fld">예매자 실명*</label>
       <input id="fName" placeholder="이름" value="${esc(prefill)}" autocomplete="name" />
+
+      <label class="fld">입금자명 *</label>
+      <input id="fDep" placeholder="입금하실 분 이름" value="${esc(prefill)}" />
+
       <label class="fld">연락처 *</label>
       <input id="fPhone" placeholder="010-0000-0000" inputmode="tel" autocomplete="tel" />
-
-      <label class="fld">결제 방법 *</label>
-      <div class="seg" id="segMethod">
-        <button type="button" data-m="bank" class="on">계좌번호</button>
-        <button type="button" data-m="qr">뱅킹앱 QR</button>
-      </div>
-
-      <label class="fld">입금자명 * <span style="font-weight:400;color:var(--dim)"></span></label>
-      <input id="fDep" placeholder="입금자 이름" value="${esc(prefill)}" />
 
       <label class="fld">수량 *</label>
       <div class="qty">
@@ -795,30 +761,16 @@ function mountBuyForm() {
         <span class="hint" style="margin:0 0 0 6px">최대 ${MAXQ}인</span>
       </div>
 
-      <label class="fld">여기로 송금해 주세요</label>
-      <div id="payArea"></div>
-
       <div class="total"><span class="lbl">총 금액</span><span class="amt" id="tAmt">${won(PRICE)}</span></div>
-      <button class="btn" id="submitBtn">입금 완료했어요 · <span id="btnAmt">${won(PRICE)}</span></button>
-      <div class="notice">위 계좌(또는 QR)로 송금한 뒤 <b>‘입금 완료했어요’</b> 버튼을 눌러주세요. 입금 확인은 <b>수동</b>이라 <b>최대 하루</b> 정도 걸릴 수 있어요. 확인되면 <b>예매하신 이메일로 티켓과 링크</b>를 보내드리고, 로그인 화면에도 공연 입장용 <b>티켓 QR</b>이 떠요. <b>📩 이메일을 확인해 주세요.</b> (메일을 못 받아도 <b>사이트에 로그인하면 언제든 확인</b> 가능)<br/><span style="color:var(--dim)">이 티켓 QR은 방금 <b style="color:var(--muted)">송금할 때 쓴 QR과는 다른</b>, 공연 당일 입장 때 보여주는 QR이에요.</span></div>
+      <button class="btn" id="submitBtn">입금 단계로 넘어가기 · <span id="btnAmt">${won(PRICE)}</span></button>
+      <div class="notice">먼저 예매자 정보를 <b>접수</b>하면, 바로 다음 화면에서 <b>입금 계좌·송금 링크</b>를 안내해 드려요. <b>지금 접수해두면 기록이 남아</b> 혹시 입금 확인이 늦어도 안전하게 처리돼요.<br/><span style="color:var(--dim)">아직 송금하지 않아도 괜찮아요 — 접수 후 안내대로 입금하시면 됩니다.</span></div>
       <div class="notice">현장 예매도 가능합니다.</div>
       <div class="err" id="formErr"></div>
     </div>`;
 
-  const seg = $("#segMethod");
-  seg.querySelectorAll("button").forEach((b) => {
-    b.onclick = () => {
-      seg.querySelectorAll("button").forEach((x) => x.classList.remove("on"));
-      b.classList.add("on");
-      FORM.method = b.dataset.m;
-      updatePayArea();
-    };
-  });
   $("#qMinus").onclick = () => setQty(FORM.qty - 1);
   $("#qPlus").onclick = () => setQty(FORM.qty + 1);
   $("#submitBtn").onclick = submitOrder;
-  updatePayArea();
-  wireCopy(mount);
 }
 
 function setQty(q) {
@@ -827,12 +779,6 @@ function setQty(q) {
   const amt = won(PRICE * FORM.qty);
   $("#tAmt").textContent = amt;
   $("#btnAmt").textContent = amt;
-  updatePayArea();
-}
-
-function updatePayArea() {
-  $("#payArea").innerHTML = paymentInstructionsHTML(FORM.method, PRICE * FORM.qty);
-  wireCopy($("#payArea"));
 }
 
 function wireCopy(root) {
@@ -925,11 +871,11 @@ async function submitOrder() {
 
   if (error) {
     btn.disabled = false;
-    btn.textContent = "입금 완료했어요";
+    btn.textContent = "입금 단계로 넘어가기";
     err.textContent = "접수 실패: " + error.message;
     return;
   }
-  toast("접수 완료! 입금 확인을 기다려주세요.");
+  toast("접수 완료! 아래 안내대로 입금해 주세요.");
   await refresh();
 }
 

--- a/ticket_2026_Janyeol/index.html
+++ b/ticket_2026_Janyeol/index.html
@@ -109,7 +109,7 @@
     integrity="sha384-De+l/Df7qym5QBDVocD3+gW1S7IjR3epf+6KbRDjB3FCCzM/LqVTwqckT6FhFar8"
     crossorigin="anonymous"></script>
   <script src="config.js?v=20260805-3"></script>
-  <script src="app.js?v=20260805-5"></script>
+  <script src="app.js?v=20260806-1"></script>
 </body>
 
 </html>

--- a/ticket_2026_Janyeol/performer.js
+++ b/ticket_2026_Janyeol/performer.js
@@ -45,6 +45,24 @@ function ensureQRCode() {
   return _qrLoad;
 }
 
+let _h2cLoad = null;
+function ensureHtml2Canvas() {
+  if (window.html2canvas) return Promise.resolve(true);
+  if (!_h2cLoad) {
+    _h2cLoad = new Promise((resolve) => {
+      const s = document.createElement("script");
+      s.src = "https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js";
+      s.integrity = "sha384-ZZ1pncU3bQe8y31yfZdMFdSpttDoPmOZg2wguVK9almUodir1PghgT0eY7Mrty8H";
+      s.crossOrigin = "anonymous";
+      s.async = true;
+      s.onload = () => resolve(true);
+      s.onerror = () => resolve(false);
+      document.head.appendChild(s);
+    });
+  }
+  return _h2cLoad;
+}
+
 async function drawQR(elId, text) {
   const ok = await ensureQRCode();
   const el = document.getElementById(elId);
@@ -179,10 +197,19 @@ async function renderLoggedIn(user) {
   wireUserbar();
   wireCopy(area);
   wireWallet(area);
+  wireTicketActions(area);
 
   if (active.length) {
     active.forEach((o) => {
-      if (o.status === "confirmed" && o.qr_token) drawQR(`qr-${o.id}`, o.qr_token);
+      if (o.status === "confirmed" && o.qr_token) {
+        drawQR(`qr-${o.id}`, o.qr_token).then((ok) => {
+          if (!ok) { setPassActionPending(`pass-${o.id}`, false); return; }
+          // QR이 그려진 뒤 저장용 이미지 준비(제스처 보존)
+          void preparePass(`pass-${o.id}`);
+        });
+        // 공유 카드는 QR이 없으므로 먼저 준비
+        void preparePass(`share-${o.id}`);
+      }
     });
   } else {
     mountApplyForm();
@@ -257,12 +284,228 @@ async function addToAppleWallet(orderId, button) {
   }
 }
 
+// ---------------- 티켓 저장 / 인스타 공유 ----------------
+function wireTicketActions(root) {
+  root.querySelectorAll("[data-save-pass]").forEach((b) => {
+    b.onclick = () => saveTicketImage(b.dataset.savePass, b.dataset.buyerName || "");
+  });
+  root.querySelectorAll("[data-share-pass]").forEach((b) => {
+    b.onclick = () => shareTicketImage(b.dataset.sharePass, b.dataset.buyerName || "");
+  });
+}
+
+// 인스타 공유용 카드(오프스크린): 티켓 모양 그대로, QR 자리에 이미 크롭된 티켓 이미지(QR 없음).
+function shareCardHTML(o) {
+  const poster = (CFG.POSTER && (CFG.POSTER.ticket || CFG.POSTER.main)) || "";
+  const fallback = (CFG.POSTER && (CFG.POSTER.ticketFallback || CFG.POSTER.mainFallback)) || "";
+  return `
+    <div style="position:fixed;left:-10000px;top:0;width:340px;pointer-events:none;" aria-hidden="true">
+      <div class="tech-ticket" id="share-${o.id}">
+        <div class="tech-ticket-head">
+          <div>
+            <div class="tech-ticket-title">${esc(EV.title || "JANYEOL")}</div>
+            <div class="tech-ticket-sub">${esc(EV.dateLabel || "8.29 SAT 5:30PM")} · ${esc(EV.venue || "001 LIVE HALL")}</div>
+          </div>
+          <div class="tech-ticket-badge">PERFORMER</div>
+        </div>
+        <div class="tech-ticket-grid">
+          <div class="tech-field"><span class="lbl">NAME</span><span class="val">${esc(o.buyer_name)}</span></div>
+          <div class="tech-field"><span class="lbl">BAND</span><span class="val">${esc(o.depositor_name || "-")}</span></div>
+          <div class="tech-field"><span class="lbl">DATE</span><span class="val">8.29 SAT</span></div>
+          <div class="tech-field"><span class="lbl">VENUE</span><span class="val">${esc(EV.venue || "001 HALL")}</span></div>
+        </div>
+        <div class="share-poster">
+          ${poster || fallback ? `<img class="share-poster-img" src="${esc(poster || fallback)}" alt="" crossorigin="anonymous" onerror="this.onerror=null;this.src='${esc(fallback)}'" />` : ""}
+        </div>
+        <div class="tech-ticket-foot"><span>JANYEOL LIVE 2026</span><span>PERFORMER</span></div>
+      </div>
+    </div>`;
+}
+
+const PASS_BLOBS = {};
+const PASS_PREPARATIONS = {};
+
+async function waitForRenderableAssets(el) {
+  try { await document.fonts?.ready; } catch (_) {}
+  const imgs = [...el.querySelectorAll("img")];
+  await Promise.all(
+    imgs.map((img) => {
+      if (img.complete && img.naturalWidth) return Promise.resolve();
+      if (img.decode) return img.decode().catch(() => {});
+      return new Promise((resolve) => { img.onload = resolve; img.onerror = resolve; });
+    })
+  );
+}
+
+async function renderPassBlob(passElementId, mime) {
+  const passEl = document.getElementById(passElementId);
+  if (!passEl) return null;
+  try {
+    const ready = await ensureHtml2Canvas();
+    if (!ready) throw new Error("html2canvas 전역 객체 없음");
+    await waitForRenderableAssets(passEl);
+  } catch (e) {
+    console.error("티켓 캡처 준비 실패:", e);
+    return null;
+  }
+  const canvas = await window.html2canvas(passEl, {
+    scale: 3, backgroundColor: "#f4f4f4", useCORS: true, logging: false,
+  });
+  const type = mime || "image/png";
+  return await new Promise((res) => canvas.toBlob(res, type, type === "image/jpeg" ? 0.95 : undefined));
+}
+
+// 공유 카드(share-*)는 JPEG, 티켓 저장(pass-*)은 PNG
+const blobMime = (id) => (id.startsWith("share-") ? "image/jpeg" : "image/png");
+
+function setPassActionPending(passElementId, pending) {
+  const attr = passElementId.startsWith("share-") ? "data-share-pass" : "data-save-pass";
+  const button = [...document.querySelectorAll(`[${attr}]`)]
+    .find((candidate) => candidate.getAttribute(attr) === passElementId);
+  if (!button) return;
+  button.disabled = pending;
+  if (pending) button.setAttribute("aria-busy", "true");
+  else button.removeAttribute("aria-busy");
+}
+
+async function preparePass(passElementId) {
+  if (PASS_BLOBS[passElementId]) {
+    setPassActionPending(passElementId, false);
+    return PASS_BLOBS[passElementId];
+  }
+  if (!PASS_PREPARATIONS[passElementId]) {
+    setPassActionPending(passElementId, true);
+    PASS_PREPARATIONS[passElementId] = renderPassBlob(passElementId, blobMime(passElementId))
+      .then((blob) => { if (blob) PASS_BLOBS[passElementId] = blob; return blob; })
+      .catch((error) => { console.error("티켓 이미지 준비 실패:", error); return null; })
+      .finally(() => { setPassActionPending(passElementId, false); delete PASS_PREPARATIONS[passElementId]; });
+  }
+  return PASS_PREPARATIONS[passElementId];
+}
+
+const isIOS = () =>
+  /iP(hone|ad|od)/.test(navigator.userAgent) ||
+  (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+
+function downloadBlob(blob, fileName) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url; link.download = fileName; link.style.display = "none";
+  document.body.appendChild(link); link.click(); link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 6000);
+}
+
+let imagePreviewUrl = "";
+let imagePreviewLastFocus = null;
+
+function closeImagePreview() {
+  const overlay = document.getElementById("imageSaveOverlay");
+  if (!overlay) return;
+  overlay.classList.add("hidden");
+  document.body.classList.remove("image-preview-open");
+  const image = overlay.querySelector("img");
+  if (image) image.removeAttribute("src");
+  if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl);
+  imagePreviewUrl = "";
+  imagePreviewLastFocus?.focus?.();
+  imagePreviewLastFocus = null;
+}
+
+function ensureImagePreview() {
+  let overlay = document.getElementById("imageSaveOverlay");
+  if (overlay) return overlay;
+  overlay = document.createElement("div");
+  overlay.id = "imageSaveOverlay";
+  overlay.className = "image-save-overlay hidden";
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("aria-labelledby", "imageSaveHint");
+  overlay.innerHTML = `
+    <div class="image-save-sheet">
+      <button type="button" class="image-save-close" aria-label="닫기">×</button>
+      <img class="image-save-preview" alt="" />
+      <p class="image-save-hint" id="imageSaveHint"></p>
+    </div>`;
+  overlay.querySelector(".image-save-close").onclick = closeImagePreview;
+  overlay.onclick = (event) => { if (event.target === overlay) closeImagePreview(); };
+  overlay.onkeydown = (event) => { if (event.key === "Escape") closeImagePreview(); };
+  document.body.appendChild(overlay);
+  return overlay;
+}
+
+function showImagePreview(blob, alt, message) {
+  const overlay = ensureImagePreview();
+  if (imagePreviewUrl) URL.revokeObjectURL(imagePreviewUrl);
+  imagePreviewUrl = URL.createObjectURL(blob);
+  imagePreviewLastFocus = document.activeElement;
+  const image = overlay.querySelector("img");
+  image.src = imagePreviewUrl;
+  image.alt = alt;
+  overlay.querySelector(".image-save-hint").textContent = message;
+  overlay.classList.remove("hidden");
+  document.body.classList.add("image-preview-open");
+  overlay.querySelector(".image-save-close").focus();
+}
+
+async function saveTicketImage(passElementId, buyerName) {
+  const fileName = `공연자티켓_${buyerName || "잔열"}.png`;
+  try {
+    let blob = PASS_BLOBS[passElementId];
+    if (!blob) { toast("티켓 이미지 생성 중…"); blob = await preparePass(passElementId); }
+    if (!blob) throw new Error("이미지 변환 실패");
+    if (isIOS() || !("download" in document.createElement("a"))) {
+      showImagePreview(blob, "잔열 공연자 입장 티켓", "이미지를 길게 눌러 ‘사진에 저장’을 선택하세요.");
+      return;
+    }
+    downloadBlob(blob, fileName);
+    toast("티켓 사진이 저장되었습니다!");
+  } catch (e) {
+    console.error("티켓 저장 실패:", e);
+    toast("저장 실패: 다시 시도해주세요");
+  }
+}
+
+async function shareTicketImage(shareElementId, buyerName) {
+  const fileName = `잔열공연자티켓_${buyerName || "잔열"}.jpg`;
+  try {
+    const ready = PASS_BLOBS[shareElementId];
+    if (!ready) {
+      toast("공유 이미지 준비 중…");
+      const prepared = await preparePass(shareElementId);
+      if (!prepared) throw new Error("이미지 변환 실패");
+      toast("공유 이미지가 준비됐어요. 다시 눌러주세요");
+      return;
+    }
+    if (navigator.share && navigator.canShare) {
+      const file = new File([ready], fileName, { type: "image/jpeg" });
+      if (navigator.canShare({ files: [file] })) {
+        try {
+          await navigator.share({ files: [file], text: "잔열 8.29 (토) 5:30PM · 001 라이브홀 🎫 #잔열" });
+          return;
+        } catch (err) {
+          if (err && err.name === "AbortError") return;
+          console.warn("공유 시트를 열지 못해 이미지 저장으로 전환:", err);
+        }
+      }
+    }
+    if (isIOS() || !("download" in document.createElement("a"))) {
+      showImagePreview(ready, "잔열 인스타 공유 이미지", "이미지를 길게 눌러 사진에 저장한 뒤 인스타 스토리에 올려주세요.");
+    } else {
+      downloadBlob(ready, fileName);
+      toast("이미지를 저장했어요! 인스타 스토리에 올려보세요");
+    }
+  } catch (e) {
+    console.error("공유 실패:", e);
+    toast("공유 준비 실패: 다시 시도해주세요");
+  }
+}
+
 function renderPerfCard(o) {
   const [label, cls] = STATUS_LABEL[o.status] || ["", ""];
   let body = "";
   if (o.status === "confirmed") {
     body = `
-      <div class="tech-ticket">
+      <div class="tech-ticket" id="pass-${o.id}">
         <div class="tech-ticket-head">
           <div>
             <div class="tech-ticket-title">${esc(EV.title || "JANYEOL")}</div>
@@ -282,9 +525,21 @@ function renderPerfCard(o) {
         </div>
         <div class="tech-ticket-foot"><span>JANYEOL LIVE 2026</span><span>PERFORMER</span></div>
       </div>
+
+      <div class="ticket-btns">
+        <button type="button" class="save-ticket-btn" data-save-pass="${esc(`pass-${o.id}`)}" data-buyer-name="${esc(o.buyer_name)}" disabled aria-busy="true">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          티켓 저장
+        </button>
+        <button type="button" class="share-ticket-btn" data-share-pass="${esc(`share-${o.id}`)}" data-buyer-name="${esc(o.buyer_name)}" disabled aria-busy="true">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5"/><circle cx="12" cy="12" r="4"/><circle cx="17.5" cy="6.5" r="1.2" fill="currentColor" stroke="none"/></svg>
+          인스타 공유
+        </button>
+      </div>
       ${appleWalletButtonHTML(o.id)}
       <div class="qr-note" style="margin-top:12px;">입장 시 위 QR을 확인자에게 보여주세요.<br/>확인되면 QR은 자동으로 만료됩니다. (화면 밝기 최대 권장)</div>
-      <div class="qr-code">코드 <code>${esc(o.qr_token)}</code> <button class="copy" data-copy="${esc(o.qr_token)}">복사</button></div>`;
+      <div class="qr-code">코드 <code>${esc(o.qr_token)}</code> <button class="copy" data-copy="${esc(o.qr_token)}">복사</button></div>
+      ${shareCardHTML(o)}`;
   } else if (o.status === "used") {
     body = `<div class="center" style="padding:18px 0 6px">
         <div class="qr-meta" style="font-size:26px">입장 완료</div>


### PR DESCRIPTION
## 요약

두 가지 변경입니다.

### 1) 예매 폼을 2페이지 위저드로 분리 (기록 유실 방지)
송금만 하고 확인 버튼을 안 눌러 기록이 안 남는 문제를 막기 위해, 기존 단일 폼을 두 화면으로 나눴습니다.

- **STEP 1** — 예매자 실명 + 연락처만 입력 → **"다음 · 입금 방법 선택"**
  → 이 시점에 `pending` 주문을 **즉시 생성**해 기록을 확보합니다. 이후 아무 것도 안 눌러도 이름·연락처가 남습니다.
- **STEP 2** — 결제 방법(계좌/뱅킹앱 QR) + 수량 + 입금자명 + 기존 입금 안내(계좌·송금 QR·토스) → **"입금 완료했어요"**
  → STEP 1 레코드를 수량/결제수단/입금자명/`paid_at`으로 업데이트하고 대기 화면으로 넘어갑니다.
- STEP 2 입력 중에는 실시간 새로고침을 억제(`WIZARD_ACTIVE`)해 화면이 바뀌지 않게 했습니다.
- 대기(내 티켓) 카드는 접수 요약(예매자/수량/금액) + (미입금 시) 계좌 안내 + 이메일 안내로 정리했습니다.

**DB**: `tk_guard_buyer_update` 트리거를 완화해 **소유자가 `pending`인 동안에만** 수량/금액/결제수단을 수정할 수 있게 했습니다(확정 후 변경, QR 토큰·소유자·상태 변경은 계속 차단). 롤백 트랜잭션 테스트로 "pending 허용 / confirmed 차단"을 확인했습니다.

### 2) 공연자 티켓에도 사진 저장 · 인스타 공유
승인된 공연자 티켓에 예매 티켓과 동일하게 **"티켓 저장"(PNG)** · **"인스타 공유"(QR 없는 포스터 카드, JPEG)** 버튼을 추가했습니다. (Apple 지갑 버튼은 기존대로)

## 변경 파일
- `app.js` — 2단계 위저드(`submitStep1`/`renderBuyStep2`/`submitStep2`), 실시간 억제, 대기 카드 정리
- `performer.js` — 티켓 저장/공유 머신러리 및 오프스크린 공유 카드 포팅
- `index.html` — app.js 캐시 버전 갱신

## 백엔드
- 마이그레이션 `allow_pending_payment_edits_by_owner` 적용 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZSE6K6bvp7cXWPpodjZRV)_